### PR TITLE
PHP request resulting in Error

### DIFF
--- a/app/controllers/goldencobra/articles_controller.rb
+++ b/app/controllers/goldencobra/articles_controller.rb
@@ -36,11 +36,6 @@ module Goldencobra
         respond_to do |format|
           format.html { render layout: "/goldencobra/bare_layout" }
         end
-      elsif request.format == "php" || params[:format].to_s == "php"
-        respond_to do |format|
-          format.php { render nothing: true, status: 406 }
-          format.html { render nothing: true, status: 406 }
-        end
       elsif request.format == "image/jpeg"  || request.format == "image/png"
         respond_to do |format|
           format.png { render text: "404", status: 404 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,50 +1,49 @@
-if RUBY_VERSION.to_f >= 1.9
-  require 'sidekiq/web'
-end
+require "sidekiq/web" if RUBY_VERSION.to_f >= 1.9
 
 Goldencobra::Engine.routes.draw do
-  get 'switch_language/:locale'        => 'articles#switch_language', as: :switch_language
-  get 'frontend_logout/:usermodel'     => 'sessions#logout', as: :frontend_logout
-  get 'manage/render_admin_menue'      => 'manage#render_admin_menue'
-  get 'call_for_support'               => 'manage#call_for_support'
-  post 'frontend_login/:usermodel'     => 'sessions#login', as: :frontend_login
-  post 'frontend_register/:usermodel'  => 'sessions#register', as: :frontend_register
-  post 'manage/article_visibility/:id' => 'manage#article_visibility'
+  get "switch_language/:locale"        => "articles#switch_language", as: :switch_language
+  get "frontend_logout/:usermodel"     => "sessions#logout", as: :frontend_logout
+  get "manage/render_admin_menue"      => "manage#render_admin_menue"
+  get "call_for_support"               => "manage#call_for_support"
+  post "frontend_login/:usermodel"     => "sessions#login", as: :frontend_login
+  post "frontend_register/:usermodel"  => "sessions#register", as: :frontend_register
+  post "manage/article_visibility/:id" => "manage#article_visibility"
 
-  if RUBY_VERSION.to_f >= 1.9
-    mount Sidekiq::Web => '/admin/background'
-  end
+  mount Sidekiq::Web => "/admin/background" if RUBY_VERSION.to_f >= 1.9
 
-  # post '/api/v1/tokens' => 'goldencobra/api/v1/tokens_controller#create'
-  namespace 'api' do
-    namespace 'v1' do
+  # post "/api/v1/tokens" => "goldencobra/api/v1/tokens_controller#create"
+  namespace "api" do
+    namespace "v1" do
       resources :tokens, only: [:create, :show]
     end
 
-    namespace 'v2' do
-      get '/articles'                 => 'articles#index'
-      get '/articles/search'          => 'articles#search'
-      get '/articles/breadcrumb/*url' => 'articles#breadcrumb'
-      get '/articles/*url'            => 'articles#show'
-      get '/locale_string'            => 'locales#get_string'
-      get '/setting_string'           => 'settings#get_string'
-      get '/uploads'                  => 'uploads#index'
-      post '/articles/create'         => 'articles#create'
-      post '/articles/update'         => 'articles#update'
-      get '/navigation_menus'         => 'navigation_menus#index'
-      get '/navigation_menus/active'  => 'navigation_menus#active_ids'
+    namespace "v2" do
+      get "/articles"                 => "articles#index"
+      get "/articles/search"          => "articles#search"
+      get "/articles/breadcrumb/*url" => "articles#breadcrumb"
+      get "/articles/*url"            => "articles#show"
+      get "/locale_string"            => "locales#get_string"
+      get "/setting_string"           => "settings#get_string"
+      get "/uploads"                  => "uploads#index"
+      post "/articles/create"         => "articles#create"
+      post "/articles/update"         => "articles#update"
+      get "/navigation_menus"         => "navigation_menus#index"
+      get "/navigation_menus/active"  => "navigation_menus#active_ids"
     end
   end
 
-  get 'sitemap', to: 'articles#sitemap', defaults: { format: 'xml' }
+  get "sitemap", to: "articles#sitemap", defaults: { format: "xml" }
 
-  devise_for :visitors, controllers: { omniauth_callbacks: 'visitors/omniauth_callbacks' }
+  devise_for :visitors, controllers: { omniauth_callbacks: "visitors/omniauth_callbacks" }
   devise_scope :visitors do
-    get '/visitors/auth/:provider' => 'omniauth_callbacks#passthru'
+    get "/visitors/auth/:provider" => "omniauth_callbacks#passthru"
   end
 
-  #match '/*article_id.pdf', to: 'articles#convert_to_pdf'
-  get '/*article_id', to: 'articles#show'
+  # match "/*article_id.pdf", to: "articles#convert_to_pdf"
+  get "/*article_id", to: "articles#show", constraints: lambda { |req|
+    # php requests results in MimeType:Null-Object Github #47
+    !["php", ""].include?(req.format.to_sym.to_s.downcase)
+  }
 
-  root to: 'articles#show', defaults: { startpage: true }
+  root to: "articles#show", defaults: { startpage: true }
 end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -15,8 +15,7 @@
   Current Visitor:  <%= debug current_visitor %>
 
   <script type="text/javascript" src="http://jira.ikusei.de/s/d41d8cd98f00b204e9800998ecf8427e/de_DE-95cttb-1988229788/6144/26/1.4.0-m6/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?collectorId=126c9cc6"></script>
-<br>
-
+  <br>
 
 
   Default Locale: <%= I18n.default_locale %>

--- a/test/dummy/spec/controllers/articles_controller_spec.rb
+++ b/test/dummy/spec/controllers/articles_controller_spec.rb
@@ -272,11 +272,10 @@ describe Goldencobra::ArticlesController, type: :controller do
 
   describe "#show" do
 
-    it "renders 406 if request.format is php" do
-      pending "Implementation works, but test does not."
+    it "renders 404 if request.format is php" do
       get :show, { format: "application/php" }
 
-      expect(response.status).to eq(406)
+      expect(response.status).to eq(404)
     end
 
     context "with a valid format" do


### PR DESCRIPTION
Requests with php are generating a MimeType:Null-Object.
In routes.rb we are now filtering requests, which match to php or nil format.

Additional Formats to exclude can now simply be added to the array.

in application_controller, the "elseif" for php is removed, rspec is modified.

fixes #47