### PR TITLE
Feature/GitHub issue 44 activate deactivate menu items

### DIFF
--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -1,37 +1,37 @@
 ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
-  menu parent: I18n.t('active_admin.menues.parent'), label: I18n.t('active_admin.menues.as'), if: proc{can?(:update, Goldencobra::Menue)}
+  menu parent: I18n.t("active_admin.menues.parent"), label: I18n.t("active_admin.menues.as"), if: proc{can?(:update, Goldencobra::Menue)}
 
-  filter :title, label: I18n.t('active_admin.menues.labels.title')
-  filter :target, label: I18n.t('active_admin.menues.labels.target')
-  filter :css_class, label: I18n.t('active_admin.menues.labels.css_class')
-  filter :sorter, label: I18n.t('active_admin.menues.labels.sorter')
+  filter :title, label: I18n.t("active_admin.menues.labels.title")
+  filter :target, label: I18n.t("active_admin.menues.labels.target")
+  filter :css_class, label: I18n.t("active_admin.menues.labels.css_class")
+  filter :sorter, label: I18n.t("active_admin.menues.labels.sorter")
 
-  scope I18n.t('active_admin.menues.active'), :active
-  scope I18n.t('active_admin.menues.inactive'), :inactive
+  scope I18n.t("active_admin.menues.active"), :active
+  scope I18n.t("active_admin.menues.inactive"), :inactive
 
   form do |f|
     f.actions
-    f.inputs I18n.t('active_admin.menues.form.generals.general') do
-      f.input :title, label: I18n.t('active_admin.menues.form.generals.title'), hint: I18n.t('active_admin.menues.form.generals.title_hint')
-      f.input :target, label: I18n.t('active_admin.menues.form.generals.target'), hint: I18n.t('active_admin.menues.form.generals.target_hint')
-      f.input :parent_id, label: I18n.t('active_admin.menues.form.generals.parent_id'), hint: I18n.t('active_admin.menues.form.generals.parent_id_hint'), as: :select, collection: Goldencobra::Menue.all.map{|c| ["#{c.path.map(&:title).join(" / ")}", c.id]}.sort{|a,b| a[0] <=> b[0]}, include_blank: true, input_html: { class: 'chosen-select-deselect', style: 'width: 80%;', 'data-placeholder' => 'Elternelement auswählen' }
-      f.input :sorter, label: I18n.t('active_admin.menues.form.options.sorter_label'), hint: I18n.t('active_admin.menues.form.options.sorter_hint')
+    f.inputs I18n.t("active_admin.menues.form.generals.general") do
+      f.input :title, label: I18n.t("active_admin.menues.form.generals.title"), hint: I18n.t("active_admin.menues.form.generals.title_hint")
+      f.input :target, label: I18n.t("active_admin.menues.form.generals.target"), hint: I18n.t("active_admin.menues.form.generals.target_hint")
+      f.input :parent_id, label: I18n.t("active_admin.menues.form.generals.parent_id"), hint: I18n.t("active_admin.menues.form.generals.parent_id_hint"), as: :select, collection: Goldencobra::Menue.all.map{|c| ["#{c.path.map(&:title).join(" / ")}", c.id]}.sort{|a,b| a[0] <=> b[0]}, include_blank: true, input_html: { class: "chosen-select-deselect", style: "width: 80%;", "data-placeholder" => "Elternelement auswählen" }
+      f.input :sorter, label: I18n.t("active_admin.menues.form.options.sorter_label"), hint: I18n.t("active_admin.menues.form.options.sorter_hint")
     end
-    f.inputs I18n.t('active_admin.menues.form.options.option'), class: "foldable closed inputs" do
-      check_box_tag "hidden", label: I18n.t('active_admin.menues.form.options.checkbox_label'), hint: I18n.t('active_admin.menues.form.options.checkbox_hint')
-      f.input :css_class, label: I18n.t('active_admin.menues.form.options.css_class_label'), hint: I18n.t('active_admin.menues.form.options.css_class_hint')
-      f.input :active, label: I18n.t('active_admin.menues.form.options.active_label'), hint: I18n.t('active_admin.menues.form.options.aktiv_hint')
-      f.input :remote, label: I18n.t('active_admin.menues.form.options.remote_label'), hint: I18n.t('active_admin.menues.form.options.remote_hint')
+    f.inputs I18n.t("active_admin.menues.form.options.option"), class: "foldable closed inputs" do
+      check_box_tag "hidden", label: I18n.t("active_admin.menues.form.options.checkbox_label"), hint: I18n.t("active_admin.menues.form.options.checkbox_hint")
+      f.input :css_class, label: I18n.t("active_admin.menues.form.options.css_class_label"), hint: I18n.t("active_admin.menues.form.options.css_class_hint")
+      f.input :active, label: I18n.t("active_admin.menues.form.options.active_label"), hint: I18n.t("active_admin.menues.form.options.aktiv_hint")
+      f.input :remote, label: I18n.t("active_admin.menues.form.options.remote_label"), hint: I18n.t("active_admin.menues.form.options.remote_hint")
     end
-    f.inputs I18n.t('active_admin.menues.form.access.access_rights'), class: "foldable closed inputs" do
+    f.inputs I18n.t("active_admin.menues.form.access.access_rights"), class: "foldable closed inputs" do
       f.has_many :permissions do |p|
-        p.input :role, include_blank: I18n.t('active_admin.menues.form.access.include_blank')
+        p.input :role, include_blank: I18n.t("active_admin.menues.form.access.include_blank")
         p.input :action, as: :select, collection: Goldencobra::Permission::PossibleActions, include_blank: false
         p.input :_destroy, as: :boolean
       end
     end
 
-    #Deprecated, will be removed in GC 2.1
+    # Deprecated, will be removed in GC 2.1
     # f.inputs I18n.t('active_admin.menues.form.details'), class: "foldable closed inputs" do
     #   f.input :image, label: I18n.t('active_admin.menues.form.image_label'), hint: I18n.t('active_admin.menues.form.image_hint'), as: :select, collection: Goldencobra::Upload.order("updated_at DESC").map{|c| [c.complete_list_name, c.id]}, input_html: { class: 'article_image_file chosen-select-deselect', style: 'width: 80%;', 'data-placeholder' => 'Bild auswählen' }
     #   f.input :description_title, label: I18n.t('active_admin.menues.form.details_description_title'), hint: ""
@@ -43,29 +43,29 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
 
   index download_links: proc{ Goldencobra::Setting.for_key("goldencobra.backend.index.download_links") == "true" }.call do
     selectable_column
-    column I18n.t('active_admin.menues.form.index.column'), :title, sortable: :title do |menue|
-      link_to(menue.title, edit_admin_menue_path(menue), title: I18n.t('active_admin.menues.form.index.title'))
+    column I18n.t("active_admin.menues.form.index.column"), :title, sortable: :title do |menue|
+      link_to(menue.title, edit_admin_menue_path(menue), title: I18n.t("active_admin.menues.form.index.title"))
     end
-    column I18n.t('active_admin.menues.form.index.column1'), :target
-    column I18n.t('active_admin.menues.form.index.column2'), :active, sortable: :active do |menue|
+    column I18n.t("active_admin.menues.form.index.column1"), :target
+    column I18n.t("active_admin.menues.form.index.column2"), :active, sortable: :active do |menue|
       raw("<span class='#{menue.active ? 'online' : 'offline'}'>#{menue.active ? 'online' : 'offline'}</span>")
     end
-    column I18n.t('active_admin.menues.form.index.column3'), :sorter
-    column I18n.t('active_admin.menues.form.index.column4') do |menue|
+    column I18n.t("active_admin.menues.form.index.column3"), :sorter
+    column I18n.t("active_admin.menues.form.index.column4") do |menue|
       Goldencobra::Permission.restricted?(menue) ? raw("<span class='secured'>beschränkt</span>") : ""
     end
-    column I18n.t('active_admin.menues.form.index.column5') do |menue|
+    column I18n.t("active_admin.menues.form.index.column5") do |menue|
       if menue.mapped_to_article?
-        link_to(I18n.t('active_admin.menues.form.index.search_link'), admin_articles_path("q[url_name_contains]" => menue.target.to_s.split('/').last), class: "list", title: I18n.t('active_admin.menues.form.index.search_title'))
+        link_to(I18n.t("active_admin.menues.form.index.search_link"), admin_articles_path("q[url_name_contains]" => menue.target.to_s.split("/").last), class: "list", title: I18n.t("active_admin.menues.form.index.search_title"))
       else
-        link_to(I18n.t('active_admin.menues.form.index.search_link1'), new_admin_article_path(article: {title: menue.title, url_name: menue.target.to_s.split('/').last}), class: "create", title: I18n.t('active_admin.menues.form.index.search_title1'))
+        link_to(I18n.t("active_admin.menues.form.index.search_link1"), new_admin_article_path(article: {title: menue.title, url_name: menue.target.to_s.split('/').last}), class: "create", title: I18n.t("active_admin.menues.form.index.search_title1"))
       end
     end
     column "" do |menue|
       result = ""
-      result += link_to(I18n.t('active_admin.menues.form.column.edit'), edit_admin_menue_path(menue), class: "member_link edit_link edit", title: I18n.t('active_admin.menues.form.column.edit_title'))
-      result += link_to(I18n.t('active_admin.menues.form.column.submenu'), new_admin_menue_path(parent: menue), class: "member_link edit_link new_subarticle", title: I18n.t('active_admin.menues.form.column.submenu_title'))
-      result += link_to(I18n.t('active_admin.menues.form.column.delete'), admin_menue_path(menue), method: :DELETE, "data-confirm" => I18n.t('active_admin.menues.form.column.delete_confirm'), class: "member_link delete_link delete", title: I18n.t('active_admin.menues.form.column.delete_title'))
+      result += link_to(I18n.t("active_admin.menues.form.column.edit"), edit_admin_menue_path(menue), class: "member_link edit_link edit", title: I18n.t("active_admin.menues.form.column.edit_title"))
+      result += link_to(I18n.t("active_admin.menues.form.column.submenu"), new_admin_menue_path(parent: menue), class: "member_link edit_link new_subarticle", title: I18n.t("active_admin.menues.form.column.submenu_title"))
+      result += link_to(I18n.t("active_admin.menues.form.column.delete"), admin_menue_path(menue), method: :DELETE, "data-confirm" => I18n.t("active_admin.menues.form.column.delete_confirm"), class: "member_link delete_link delete", title: I18n.t("active_admin.menues.form.column.delete_title"))
       raw(result)
     end
   end
@@ -116,21 +116,21 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
 
   #batch_action :destroy, false
 
-  batch_action :set_menue_offline, "data-confirm" => I18n.t('active_admin.menues.form.column.batch_action.confirm') do |selection|
+  batch_action :set_menue_offline, "data-confirm" => I18n.t("active_admin.menues.form.column.batch_action.confirm") do |selection|
     Goldencobra::Menue.find(selection).each do |menue|
       menue.active = false
       menue.save
     end
-    flash["notice"] = I18n.t('active_admin.menues.form.column.batch_action.flash')
+    flash["notice"] = I18n.t("active_admin.menues.form.column.batch_action.flash")
     redirect_to action: :index
   end
 
-  batch_action :set_menue_online, "data-confirm" => I18n.t('active_admin.menues.form.column.batch_action.confirm1') do |selection|
+  batch_action :set_menue_online, "data-confirm" => I18n.t("active_admin.menues.form.column.batch_action.confirm1") do |selection|
     Goldencobra::Menue.find(selection).each do |menue|
       menue.active = true
       menue.save
     end
-    flash["notice"] = I18n.t('active_admin.menues.form.column.batch_action.flash1')
+    flash["notice"] = I18n.t("active_admin.menues.form.column.batch_action.flash1")
     redirect_to action: :index
   end
 
@@ -154,7 +154,7 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
     redirect_to :back, notice: "#{I18n.t('active_admin.menues.form.member_action.notice')} #{@version.event}"
   end
 
-  batch_action :clone, "data-confirm" => I18n.t('active_admin.menues.form.batch_action.confirm_clone') do |selection|
+  batch_action :clone, "data-confirm" => I18n.t("active_admin.menues.form.batch_action.confirm_clone") do |selection|
     Goldencobra::Menue.find(selection).each do |menue|
       Goldencobra::Menue.create(
         title: "#{I18n.t('active_admin.menues.form.batch_action.title_clone')} #{menue.title}",
@@ -169,22 +169,22 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
         image_id: menue.image_id
       )
     end
-    flash["notice"] = I18n.t('active_admin.menues.form.batch_action.flash_clone')
+    flash["notice"] = I18n.t("active_admin.menues.form.batch_action.flash_clone")
     redirect_to action: :index
   end
 
   action_item :prev_item, only: [:edit, :show] do
-    render partial: '/goldencobra/admin/shared/prev_item'
+    render partial: "/goldencobra/admin/shared/prev_item"
   end
 
   action_item :undo, only: :edit do
     if resource.versions.last
-      link_to(I18n.t('active_admin.menues.form.action_item.link_to'), revert_admin_menue_path(id: resource.versions.last), class: "undo")
+      link_to(I18n.t("active_admin.menues.form.action_item.link_to"), revert_admin_menue_path(id: resource.versions.last), class: "undo")
     end
   end
 
   action_item :next_item, only: [:edit, :show] do
-    render partial: '/goldencobra/admin/shared/next_item'
+    render partial: "/goldencobra/admin/shared/next_item"
   end
 
   controller do

--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -48,7 +48,10 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
     end
     column I18n.t("active_admin.menues.form.index.column1"), :target
     column I18n.t("active_admin.menues.form.index.column2"), :active, sortable: :active do |menue|
-      raw("<span class='#{menue.active ? 'online' : 'offline'}'>#{menue.active ? 'online' : 'offline'}</span>")
+      link_to(menue.active ? "online" : "offline", activate_deactivate_menu_item_admin_menue_path(menue),
+              title: "#{menue.active ? I18n.t("active_admin.menues.member_action.set_menu_item_offline") : I18n.t("active_admin.menues.member_action.set_menu_item_online")}",
+              "data-confirm" => I18n.t("change_menu_visibility", scope: [:goldencobra, :flash_notice]),
+              class: "member_link edit_link #{menue.active ? 'online' : 'offline'}")
     end
     column I18n.t("active_admin.menues.form.index.column3"), :sorter
     column I18n.t("active_admin.menues.form.index.column4") do |menue|
@@ -92,7 +95,6 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
   end
 
   collection_action :load_overviewtree_as_json do
-
     if params[:root_id].present?
       objects = Goldencobra::Menue.where(id: params[:root_id]).first.children.reorder(:title)
       cache_key ||= ["menus", params[:root_id], objects.map(&:id), objects.maximum(:updated_at)]
@@ -154,6 +156,20 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
     redirect_to :back, notice: "#{I18n.t('active_admin.menues.form.member_action.notice')} #{@version.event}"
   end
 
+  member_action :activate_deactivate_menu_item do
+    menu_item = Goldencobra::Menue.find(params[:id])
+    if menu_item.active
+      menu_item.active = false
+      flash[:notice] = I18n.t("active_admin.menues.member_action.flash.menu_item_offline")
+    else
+      menu_item.active = true
+      flash[:notice] = I18n.t("active_admin.menues.member_action.flash.menu_item_online")
+    end
+    menu_item.save
+
+    redirect_to action: :index
+  end
+
   batch_action :clone, "data-confirm" => I18n.t("active_admin.menues.form.batch_action.confirm_clone") do |selection|
     Goldencobra::Menue.find(selection).each do |menue|
       Goldencobra::Menue.create(
@@ -194,5 +210,4 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
       end
     end
   end
-
 end

--- a/config/locales/active_admin.de.yml
+++ b/config/locales/active_admin.de.yml
@@ -5,6 +5,7 @@ de:
       action_Startpage: "Diesen Artikel als Startseite einrichten"
       startpage: "Dieser Artikel ist nun der Startartikel"
       online: "Sichtbarkeit dieses Artikels ändern?"
+      change_menu_visibility: "Sichtbarkeit dieses Menüpunktes ändern?"
       delete_article: "Artikel wirklich löschen?"
     filter:
       filter_titel: "Titel"
@@ -297,8 +298,8 @@ de:
         h5_achtung4: "mit dieser URL:"
       member_action:
         flash:
-          article_online: "Dieser Artikel ist nun online"
-          article_offline: "Dieser Artikel ist nun offline"
+          article_online: "Dieser Artikel ist nun online."
+          article_offline: "Dieser Artikel ist nun offline."
           widgets: "Widgets added"
           link_checker: "Die Links dieses Artikels werden überprüft. Bitte warten Sie, dies kann wenige Minuten in Anspruch nehmen."
       batch_action:
@@ -431,6 +432,12 @@ de:
           notice: "Rückgängig:"
         action_item:
           link_to: "rückgängig"
+      member_action:
+        set_menu_item_online: "Diesen Menüpunkt online schalten."
+        set_menu_item_offline: "Diesen Menüpunkt offline schalten."
+        flash:
+          menu_item_online: "Dieser Menüpunkt ist nun online."
+          menu_item_offline: "Dieser Menüpunkt ist nun offline."
     permissions:
       as: "Zugriffsrechte"
       scope: "Alle"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -5,6 +5,7 @@ en:
       action_Startpage: "Make this article startpage"
       startpage: "This article is the startpage!"
       online: "Change the visibility of the article?"
+      change_menu_visibility: "Change the visibility of this menu item?"
       delete_article: "Really want to delete this article?"
     filter:
       filter_titel: "Title"
@@ -431,6 +432,12 @@ en:
           notice: "Undo:"
         action_item:
           link_to: "undo"
+      member_action:
+        set_menu_item_online: "Set this menu item online."
+        set_menu_item_offline: "Set this menu item offline."
+        flash:
+          menu_item_online: "This menu item is now online."
+          menu_item_offline: "This menu item is now offline."
     permissions:
       as: "Permissions"
       scope: "All"

--- a/doc/versionhistory
+++ b/doc/versionhistory
@@ -1,4 +1,6 @@
-V2.0.17 -30.05.2016
+V2.0.17.1 - 13.06.2016
+  - set visibility of menu item directly from admin menu index view like already known from articles
+V2.0.17 - 30.05.2016
   - CreatorId editable in backend
   - Article states added (empty, draft, in_review, waiting, published, discarded)
   - Filters for creator and state added

--- a/lib/goldencobra/version.rb
+++ b/lib/goldencobra/version.rb
@@ -1,3 +1,3 @@
 module Goldencobra
-  VERSION = "2.0.17"
+  VERSION = "2.0.17.1"
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,162 +1,207 @@
 # encoding: utf-8
-require 'inherited_resources'
+require "inherited_resources"
+
 Rails.application.routes.draw do
   devise_for :users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   mount Goldencobra::Engine => "/"
 end
+
 #== Route Map
-#                       admin_dashboard            /admin(.:format)                                      admin/dashboard#index
-#       mark_as_startpage_admin_article GET        /admin/articles/:id/mark_as_startpage(.:format)       admin/articles#mark_as_startpage
-# set_page_online_offline_admin_article GET        /admin/articles/:id/set_page_online_offline(.:format) admin/articles#set_page_online_offline
-#          update_widgets_admin_article POST       /admin/articles/:id/update_widgets(.:format)          admin/articles#update_widgets
-#      toggle_expert_mode_admin_article GET        /admin/articles/:id/toggle_expert_mode(.:format)      admin/articles#toggle_expert_mode
-#                  revert_admin_article GET        /admin/articles/:id/revert(.:format)                  admin/articles#revert
-#           batch_action_admin_articles POST       /admin/articles/batch_action(.:format)                admin/articles#batch_action
-#                        admin_articles GET        /admin/articles(.:format)                             admin/articles#index
-#                                       POST       /admin/articles(.:format)                             admin/articles#create
-#                     new_admin_article GET        /admin/articles/new(.:format)                         admin/articles#new
-#                    edit_admin_article GET        /admin/articles/:id/edit(.:format)                    admin/articles#edit
-#                         admin_article GET        /admin/articles/:id(.:format)                         admin/articles#show
-#                                       PUT        /admin/articles/:id(.:format)                         admin/articles#update
-#                                       DELETE     /admin/articles/:id(.:format)                         admin/articles#destroy
-#   batch_action_admin_article_comments POST       /admin/article_comments/batch_action(.:format)        admin/article_comments#batch_action
-#                admin_article_comments GET        /admin/article_comments(.:format)                     admin/article_comments#index
-#                                       POST       /admin/article_comments(.:format)                     admin/article_comments#create
-#             new_admin_article_comment GET        /admin/article_comments/new(.:format)                 admin/article_comments#new
-#            edit_admin_article_comment GET        /admin/article_comments/:id/edit(.:format)            admin/article_comments#edit
-#                 admin_article_comment GET        /admin/article_comments/:id(.:format)                 admin/article_comments#show
-#                                       PUT        /admin/article_comments/:id(.:format)                 admin/article_comments#update
-#                                       DELETE     /admin/article_comments/:id(.:format)                 admin/article_comments#destroy
-#               admin_goldencobra_infos            /admin/goldencobra_infos(.:format)                    admin/goldencobra_infos#index
-#                      run_admin_import GET        /admin/imports/:id/run(.:format)                      admin/imports#run
-#               assignment_admin_import GET        /admin/imports/:id/assignment(.:format)               admin/imports#assignment
-#            batch_action_admin_imports POST       /admin/imports/batch_action(.:format)                 admin/imports#batch_action
-#                         admin_imports GET        /admin/imports(.:format)                              admin/imports#index
-#                                       POST       /admin/imports(.:format)                              admin/imports#create
-#                      new_admin_import GET        /admin/imports/new(.:format)                          admin/imports#new
-#                     edit_admin_import GET        /admin/imports/:id/edit(.:format)                     admin/imports#edit
-#                          admin_import GET        /admin/imports/:id(.:format)                          admin/imports#show
-#                                       PUT        /admin/imports/:id(.:format)                          admin/imports#update
-#                                       DELETE     /admin/imports/:id(.:format)                          admin/imports#destroy
-#                    revert_admin_menue GET        /admin/menues/:id/revert(.:format)                    admin/menues#revert
-#             batch_action_admin_menues POST       /admin/menues/batch_action(.:format)                  admin/menues#batch_action
-#                          admin_menues GET        /admin/menues(.:format)                               admin/menues#index
-#                                       POST       /admin/menues(.:format)                               admin/menues#create
-#                       new_admin_menue GET        /admin/menues/new(.:format)                           admin/menues#new
-#                      edit_admin_menue GET        /admin/menues/:id/edit(.:format)                      admin/menues#edit
-#                           admin_menue GET        /admin/menues/:id(.:format)                           admin/menues#show
-#                                       PUT        /admin/menues/:id(.:format)                           admin/menues#update
-#                                       DELETE     /admin/menues/:id(.:format)                           admin/menues#destroy
-#        batch_action_admin_permissions POST       /admin/permissions/batch_action(.:format)             admin/permissions#batch_action
-#                     admin_permissions GET        /admin/permissions(.:format)                          admin/permissions#index
-#                                       POST       /admin/permissions(.:format)                          admin/permissions#create
-#                  new_admin_permission GET        /admin/permissions/new(.:format)                      admin/permissions#new
-#                 edit_admin_permission GET        /admin/permissions/:id/edit(.:format)                 admin/permissions#edit
-#                      admin_permission GET        /admin/permissions/:id(.:format)                      admin/permissions#show
-#                                       PUT        /admin/permissions/:id(.:format)                      admin/permissions#update
-#                                       DELETE     /admin/permissions/:id(.:format)                      admin/permissions#destroy
-#              batch_action_admin_roles POST       /admin/roles/batch_action(.:format)                   admin/roles#batch_action
-#                           admin_roles GET        /admin/roles(.:format)                                admin/roles#index
-#                                       POST       /admin/roles(.:format)                                admin/roles#create
-#                        new_admin_role GET        /admin/roles/new(.:format)                            admin/roles#new
-#                       edit_admin_role GET        /admin/roles/:id/edit(.:format)                       admin/roles#edit
-#                            admin_role GET        /admin/roles/:id(.:format)                            admin/roles#show
-#                                       PUT        /admin/roles/:id(.:format)                            admin/roles#update
-#                                       DELETE     /admin/roles/:id(.:format)                            admin/roles#destroy
-#                  revert_admin_setting GET        /admin/settings/:id/revert(.:format)                  admin/settings#revert
-#           batch_action_admin_settings POST       /admin/settings/batch_action(.:format)                admin/settings#batch_action
-#                        admin_settings GET        /admin/settings(.:format)                             admin/settings#index
-#                                       POST       /admin/settings(.:format)                             admin/settings#create
-#                     new_admin_setting GET        /admin/settings/new(.:format)                         admin/settings#new
-#                    edit_admin_setting GET        /admin/settings/:id/edit(.:format)                    admin/settings#edit
-#                         admin_setting GET        /admin/settings/:id(.:format)                         admin/settings#show
-#                                       PUT        /admin/settings/:id(.:format)                         admin/settings#update
-#                                       DELETE     /admin/settings/:id(.:format)                         admin/settings#destroy
-#               unzip_file_admin_upload GET        /admin/uploads/:id/unzip_file(.:format)               admin/uploads#unzip_file
-#            batch_action_admin_uploads POST       /admin/uploads/batch_action(.:format)                 admin/uploads#batch_action
-#                         admin_uploads GET        /admin/uploads(.:format)                              admin/uploads#index
-#                                       POST       /admin/uploads(.:format)                              admin/uploads#create
-#                      new_admin_upload GET        /admin/uploads/new(.:format)                          admin/uploads#new
-#                     edit_admin_upload GET        /admin/uploads/:id/edit(.:format)                     admin/uploads#edit
-#                          admin_upload GET        /admin/uploads/:id(.:format)                          admin/uploads#show
-#                                       PUT        /admin/uploads/:id(.:format)                          admin/uploads#update
-#                                       DELETE     /admin/uploads/:id(.:format)                          admin/uploads#destroy
-#              batch_action_admin_users POST       /admin/users/batch_action(.:format)                   admin/users#batch_action
-#                           admin_users GET        /admin/users(.:format)                                admin/users#index
-#                                       POST       /admin/users(.:format)                                admin/users#create
-#                        new_admin_user GET        /admin/users/new(.:format)                            admin/users#new
-#                       edit_admin_user GET        /admin/users/:id/edit(.:format)                       admin/users#edit
-#                            admin_user GET        /admin/users/:id(.:format)                            admin/users#show
-#                                       PUT        /admin/users/:id(.:format)                            admin/users#update
-#                                       DELETE     /admin/users/:id(.:format)                            admin/users#destroy
-#      switch_lock_status_admin_visitor GET        /admin/visitors/:id/switch_lock_status(.:format)      admin/visitors#switch_lock_status
-#           batch_action_admin_visitors POST       /admin/visitors/batch_action(.:format)                admin/visitors#batch_action
-#                        admin_visitors GET        /admin/visitors(.:format)                             admin/visitors#index
-#                                       POST       /admin/visitors(.:format)                             admin/visitors#create
-#                     new_admin_visitor GET        /admin/visitors/new(.:format)                         admin/visitors#new
-#                    edit_admin_visitor GET        /admin/visitors/:id/edit(.:format)                    admin/visitors#edit
-#                         admin_visitor GET        /admin/visitors/:id(.:format)                         admin/visitors#show
-#                                       PUT        /admin/visitors/:id(.:format)                         admin/visitors#update
-#                                       DELETE     /admin/visitors/:id(.:format)                         admin/visitors#destroy
-#                   revert_admin_widget GET        /admin/widgets/:id/revert(.:format)                   admin/widgets#revert
-#            batch_action_admin_widgets POST       /admin/widgets/batch_action(.:format)                 admin/widgets#batch_action
-#                         admin_widgets GET        /admin/widgets(.:format)                              admin/widgets#index
-#                                       POST       /admin/widgets(.:format)                              admin/widgets#create
-#                      new_admin_widget GET        /admin/widgets/new(.:format)                          admin/widgets#new
-#                     edit_admin_widget GET        /admin/widgets/:id/edit(.:format)                     admin/widgets#edit
-#                          admin_widget GET        /admin/widgets/:id(.:format)                          admin/widgets#show
-#                                       PUT        /admin/widgets/:id(.:format)                          admin/widgets#update
-#                                       DELETE     /admin/widgets/:id(.:format)                          admin/widgets#destroy
-#           batch_action_admin_comments POST       /admin/comments/batch_action(.:format)                admin/comments#batch_action
-#                        admin_comments GET        /admin/comments(.:format)                             admin/comments#index
-#                                       POST       /admin/comments(.:format)                             admin/comments#create
-#                     new_admin_comment GET        /admin/comments/new(.:format)                         admin/comments#new
-#                    edit_admin_comment GET        /admin/comments/:id/edit(.:format)                    admin/comments#edit
-#                         admin_comment GET        /admin/comments/:id(.:format)                         admin/comments#show
-#                                       PUT        /admin/comments/:id(.:format)                         admin/comments#update
-#                                       DELETE     /admin/comments/:id(.:format)                         admin/comments#destroy
-#                      new_user_session GET        /admin/login(.:format)                                active_admin/devise/sessions#new
-#                          user_session POST       /admin/login(.:format)                                active_admin/devise/sessions#create
-#                  destroy_user_session DELETE|GET /admin/logout(.:format)                               active_admin/devise/sessions#destroy
-#                         user_password POST       /admin/password(.:format)                             active_admin/devise/passwords#create
-#                     new_user_password GET        /admin/password/new(.:format)                         active_admin/devise/passwords#new
-#                    edit_user_password GET        /admin/password/edit(.:format)                        active_admin/devise/passwords#edit
-#                                       PUT        /admin/password(.:format)                             active_admin/devise/passwords#update
-#              cancel_user_registration GET        /admin/cancel(.:format)                               devise/registrations#cancel
-#                     user_registration POST       /admin(.:format)                                      devise/registrations#create
-#                 new_user_registration GET        /admin/sign_up(.:format)                              devise/registrations#new
-#                edit_user_registration GET        /admin/edit(.:format)                                 devise/registrations#edit
-#                                       PUT        /admin(.:format)                                      devise/registrations#update
-#                                       DELETE     /admin(.:format)                                      devise/registrations#destroy
-#                           user_unlock POST       /admin/unlock(.:format)                               devise/unlocks#create
-#                       new_user_unlock GET        /admin/unlock/new(.:format)                           devise/unlocks#new
-#                                       GET        /admin/unlock(.:format)                               devise/unlocks#show
-#                           goldencobra            /                                                     Goldencobra::Engine
+#                                    Prefix Verb       URI Pattern                                               Controller#Action
+#                          new_user_session GET        /admin/login(.:format)                                    active_admin/devise/sessions#new
+#                              user_session POST       /admin/login(.:format)                                    active_admin/devise/sessions#create
+#                      destroy_user_session DELETE|GET /admin/logout(.:format)                                   active_admin/devise/sessions#destroy
+#                             user_password POST       /admin/password(.:format)                                 active_admin/devise/passwords#create
+#                         new_user_password GET        /admin/password/new(.:format)                             active_admin/devise/passwords#new
+#                        edit_user_password GET        /admin/password/edit(.:format)                            active_admin/devise/passwords#edit
+#                                           PATCH      /admin/password(.:format)                                 active_admin/devise/passwords#update
+#                                           PUT        /admin/password(.:format)                                 active_admin/devise/passwords#update
+#                  cancel_user_registration GET        /admin/cancel(.:format)                                   active_admin/devise/registrations#cancel
+#                         user_registration POST       /admin(.:format)                                          active_admin/devise/registrations#create
+#                     new_user_registration GET        /admin/sign_up(.:format)                                  active_admin/devise/registrations#new
+#                    edit_user_registration GET        /admin/edit(.:format)                                     active_admin/devise/registrations#edit
+#                                           PATCH      /admin(.:format)                                          active_admin/devise/registrations#update
+#                                           PUT        /admin(.:format)                                          active_admin/devise/registrations#update
+#                                           DELETE     /admin(.:format)                                          active_admin/devise/registrations#destroy
+#                               user_unlock POST       /admin/unlock(.:format)                                   active_admin/devise/unlocks#create
+#                           new_user_unlock GET        /admin/unlock/new(.:format)                               active_admin/devise/unlocks#new
+#                                           GET        /admin/unlock(.:format)                                   active_admin/devise/unlocks#show
+#                                admin_root GET        /admin(.:format)                                          admin/dashboard#index
+#          change_articletype_admin_article POST       /admin/articles/:id/change_articletype(.:format)          admin/articles#change_articletype
+#           mark_as_startpage_admin_article GET        /admin/articles/:id/mark_as_startpage(.:format)           admin/articles#mark_as_startpage
+#     set_page_online_offline_admin_article GET        /admin/articles/:id/set_page_online_offline(.:format)     admin/articles#set_page_online_offline
+#              update_widgets_admin_article POST       /admin/articles/:id/update_widgets(.:format)              admin/articles#update_widgets
+#            run_link_checker_admin_article GET        /admin/articles/:id/run_link_checker(.:format)            admin/articles#run_link_checker
+#                      revert_admin_article GET        /admin/articles/:id/revert(.:format)                      admin/articles#revert
+#  load_overviewtree_as_json_admin_articles GET        /admin/articles/load_overviewtree_as_json(.:format)       admin/articles#load_overviewtree_as_json
+#               batch_action_admin_articles POST       /admin/articles/batch_action(.:format)                    admin/articles#batch_action
+#                            admin_articles GET        /admin/articles(.:format)                                 admin/articles#index
+#                                           POST       /admin/articles(.:format)                                 admin/articles#create
+#                         new_admin_article GET        /admin/articles/new(.:format)                             admin/articles#new
+#                        edit_admin_article GET        /admin/articles/:id/edit(.:format)                        admin/articles#edit
+#                             admin_article GET        /admin/articles/:id(.:format)                             admin/articles#show
+#                                           PATCH      /admin/articles/:id(.:format)                             admin/articles#update
+#                                           PUT        /admin/articles/:id(.:format)                             admin/articles#update
+#                                           DELETE     /admin/articles/:id(.:format)                             admin/articles#destroy
+#           batch_action_admin_articletypes POST       /admin/articletypes/batch_action(.:format)                admin/articletypes#batch_action
+#                        admin_articletypes GET        /admin/articletypes(.:format)                             admin/articletypes#index
+#                                           POST       /admin/articletypes(.:format)                             admin/articletypes#create
+#                     new_admin_articletype GET        /admin/articletypes/new(.:format)                         admin/articletypes#new
+#                    edit_admin_articletype GET        /admin/articletypes/:id/edit(.:format)                    admin/articletypes#edit
+#                         admin_articletype GET        /admin/articletypes/:id(.:format)                         admin/articletypes#show
+#                                           PATCH      /admin/articletypes/:id(.:format)                         admin/articletypes#update
+#                                           PUT        /admin/articletypes/:id(.:format)                         admin/articletypes#update
+#                                           DELETE     /admin/articletypes/:id(.:format)                         admin/articletypes#destroy
+#                           admin_dashboard GET        /admin/dashboard(.:format)                                admin/dashboard#index
+#                batch_action_admin_domains POST       /admin/domains/batch_action(.:format)                     admin/domains#batch_action
+#                             admin_domains GET        /admin/domains(.:format)                                  admin/domains#index
+#                                           POST       /admin/domains(.:format)                                  admin/domains#create
+#                          new_admin_domain GET        /admin/domains/new(.:format)                              admin/domains#new
+#                         edit_admin_domain GET        /admin/domains/:id/edit(.:format)                         admin/domains#edit
+#                              admin_domain GET        /admin/domains/:id(.:format)                              admin/domains#show
+#                                           PATCH      /admin/domains/:id(.:format)                              admin/domains#update
+#                                           PUT        /admin/domains/:id(.:format)                              admin/domains#update
+#                                           DELETE     /admin/domains/:id(.:format)                              admin/domains#destroy
+#                        admin_linkcheckers GET        /admin/linkcheckers(.:format)                             admin/linkcheckers#index
+#                        revert_admin_menue GET        /admin/menues/:id/revert(.:format)                        admin/menues#revert
+# activate_deactivate_menu_item_admin_menue GET        /admin/menues/:id/activate_deactivate_menu_item(.:format) admin/menues#activate_deactivate_menu_item
+#    load_overviewtree_as_json_admin_menues GET        /admin/menues/load_overviewtree_as_json(.:format)         admin/menues#load_overviewtree_as_json
+#                 batch_action_admin_menues POST       /admin/menues/batch_action(.:format)                      admin/menues#batch_action
+#                              admin_menues GET        /admin/menues(.:format)                                   admin/menues#index
+#                                           POST       /admin/menues(.:format)                                   admin/menues#create
+#                           new_admin_menue GET        /admin/menues/new(.:format)                               admin/menues#new
+#                          edit_admin_menue GET        /admin/menues/:id/edit(.:format)                          admin/menues#edit
+#                               admin_menue GET        /admin/menues/:id(.:format)                               admin/menues#show
+#                                           PATCH      /admin/menues/:id(.:format)                               admin/menues#update
+#                                           PUT        /admin/menues/:id(.:format)                               admin/menues#update
+#                                           DELETE     /admin/menues/:id(.:format)                               admin/menues#destroy
+#            batch_action_admin_permissions POST       /admin/permissions/batch_action(.:format)                 admin/permissions#batch_action
+#                         admin_permissions GET        /admin/permissions(.:format)                              admin/permissions#index
+#                                           POST       /admin/permissions(.:format)                              admin/permissions#create
+#                      new_admin_permission GET        /admin/permissions/new(.:format)                          admin/permissions#new
+#                     edit_admin_permission GET        /admin/permissions/:id/edit(.:format)                     admin/permissions#edit
+#                          admin_permission GET        /admin/permissions/:id(.:format)                          admin/permissions#show
+#                                           PATCH      /admin/permissions/:id(.:format)                          admin/permissions#update
+#                                           PUT        /admin/permissions/:id(.:format)                          admin/permissions#update
+#                                           DELETE     /admin/permissions/:id(.:format)                          admin/permissions#destroy
+#            batch_action_admin_redirectors POST       /admin/redirectors/batch_action(.:format)                 admin/redirectors#batch_action
+#                         admin_redirectors GET        /admin/redirectors(.:format)                              admin/redirectors#index
+#                                           POST       /admin/redirectors(.:format)                              admin/redirectors#create
+#                      new_admin_redirector GET        /admin/redirectors/new(.:format)                          admin/redirectors#new
+#                     edit_admin_redirector GET        /admin/redirectors/:id/edit(.:format)                     admin/redirectors#edit
+#                          admin_redirector GET        /admin/redirectors/:id(.:format)                          admin/redirectors#show
+#                                           PATCH      /admin/redirectors/:id(.:format)                          admin/redirectors#update
+#                                           PUT        /admin/redirectors/:id(.:format)                          admin/redirectors#update
+#                                           DELETE     /admin/redirectors/:id(.:format)                          admin/redirectors#destroy
+#                  batch_action_admin_roles POST       /admin/roles/batch_action(.:format)                       admin/roles#batch_action
+#                               admin_roles GET        /admin/roles(.:format)                                    admin/roles#index
+#                                           POST       /admin/roles(.:format)                                    admin/roles#create
+#                            new_admin_role GET        /admin/roles/new(.:format)                                admin/roles#new
+#                           edit_admin_role GET        /admin/roles/:id/edit(.:format)                           admin/roles#edit
+#                                admin_role GET        /admin/roles/:id(.:format)                                admin/roles#show
+#                                           PATCH      /admin/roles/:id(.:format)                                admin/roles#update
+#                                           PUT        /admin/roles/:id(.:format)                                admin/roles#update
+#                                           DELETE     /admin/roles/:id(.:format)                                admin/roles#destroy
+#                      revert_admin_setting GET        /admin/settings/:id/revert(.:format)                      admin/settings#revert
+#  load_overviewtree_as_json_admin_settings GET        /admin/settings/load_overviewtree_as_json(.:format)       admin/settings#load_overviewtree_as_json
+#               batch_action_admin_settings POST       /admin/settings/batch_action(.:format)                    admin/settings#batch_action
+#                            admin_settings GET        /admin/settings(.:format)                                 admin/settings#index
+#                                           POST       /admin/settings(.:format)                                 admin/settings#create
+#                         new_admin_setting GET        /admin/settings/new(.:format)                             admin/settings#new
+#                        edit_admin_setting GET        /admin/settings/:id/edit(.:format)                        admin/settings#edit
+#                             admin_setting GET        /admin/settings/:id(.:format)                             admin/settings#show
+#                                           PATCH      /admin/settings/:id(.:format)                             admin/settings#update
+#                                           PUT        /admin/settings/:id(.:format)                             admin/settings#update
+#                                           DELETE     /admin/settings/:id(.:format)                             admin/settings#destroy
+#           batch_action_admin_translations POST       /admin/translations/batch_action(.:format)                admin/translations#batch_action
+#                        admin_translations GET        /admin/translations(.:format)                             admin/translations#index
+#                                           POST       /admin/translations(.:format)                             admin/translations#create
+#                     new_admin_translation GET        /admin/translations/new(.:format)                         admin/translations#new
+#                    edit_admin_translation GET        /admin/translations/:id/edit(.:format)                    admin/translations#edit
+#                         admin_translation GET        /admin/translations/:id(.:format)                         admin/translations#show
+#                                           PATCH      /admin/translations/:id(.:format)                         admin/translations#update
+#                                           PUT        /admin/translations/:id(.:format)                         admin/translations#update
+#                                           DELETE     /admin/translations/:id(.:format)                         admin/translations#destroy
+#                   unzip_file_admin_upload GET        /admin/uploads/:id/unzip_file(.:format)                   admin/uploads#unzip_file
+#                batch_action_admin_uploads POST       /admin/uploads/batch_action(.:format)                     admin/uploads#batch_action
+#                             admin_uploads GET        /admin/uploads(.:format)                                  admin/uploads#index
+#                                           POST       /admin/uploads(.:format)                                  admin/uploads#create
+#                          new_admin_upload GET        /admin/uploads/new(.:format)                              admin/uploads#new
+#                         edit_admin_upload GET        /admin/uploads/:id/edit(.:format)                         admin/uploads#edit
+#                              admin_upload GET        /admin/uploads/:id(.:format)                              admin/uploads#show
+#                                           PATCH      /admin/uploads/:id(.:format)                              admin/uploads#update
+#                                           PUT        /admin/uploads/:id(.:format)                              admin/uploads#update
+#                                           DELETE     /admin/uploads/:id(.:format)                              admin/uploads#destroy
+#                  batch_action_admin_users POST       /admin/users/batch_action(.:format)                       admin/users#batch_action
+#                               admin_users GET        /admin/users(.:format)                                    admin/users#index
+#                                           POST       /admin/users(.:format)                                    admin/users#create
+#                            new_admin_user GET        /admin/users/new(.:format)                                admin/users#new
+#                           edit_admin_user GET        /admin/users/:id/edit(.:format)                           admin/users#edit
+#                                admin_user GET        /admin/users/:id(.:format)                                admin/users#show
+#                                           PATCH      /admin/users/:id(.:format)                                admin/users#update
+#                                           PUT        /admin/users/:id(.:format)                                admin/users#update
+#                                           DELETE     /admin/users/:id(.:format)                                admin/users#destroy
+#                       revert_admin_widget GET        /admin/widgets/:id/revert(.:format)                       admin/widgets#revert
+#                    duplicate_admin_widget GET        /admin/widgets/:id/duplicate(.:format)                    admin/widgets#duplicate
+#                batch_action_admin_widgets POST       /admin/widgets/batch_action(.:format)                     admin/widgets#batch_action
+#                             admin_widgets GET        /admin/widgets(.:format)                                  admin/widgets#index
+#                                           POST       /admin/widgets(.:format)                                  admin/widgets#create
+#                          new_admin_widget GET        /admin/widgets/new(.:format)                              admin/widgets#new
+#                         edit_admin_widget GET        /admin/widgets/:id/edit(.:format)                         admin/widgets#edit
+#                              admin_widget GET        /admin/widgets/:id(.:format)                              admin/widgets#show
+#                                           PATCH      /admin/widgets/:id(.:format)                              admin/widgets#update
+#                                           PUT        /admin/widgets/:id(.:format)                              admin/widgets#update
+#                                           DELETE     /admin/widgets/:id(.:format)                              admin/widgets#destroy
+#                            admin_comments GET        /admin/comments(.:format)                                 admin/comments#index
+#                                           POST       /admin/comments(.:format)                                 admin/comments#create
+#                             admin_comment GET        /admin/comments/:id(.:format)                             admin/comments#show
+#                                           DELETE     /admin/comments/:id(.:format)                             admin/comments#destroy
+#                               goldencobra            /                                                         Goldencobra::Engine
 
 # Routes for Goldencobra::Engine:
-#                 sidekiq_web          /admin/background                         Sidekiq::Web
-#               api_v1_tokens POST     /api/v1/tokens(.:format)                  goldencobra/api/v1/tokens#create
-#                     sitemap GET      /sitemap(.:format)                        goldencobra/articles#sitemap {:format=>"xml"}
-#         new_visitor_session GET      /visitors/sign_in(.:format)               goldencobra/sessions#new
-#             visitor_session POST     /visitors/sign_in(.:format)               goldencobra/sessions#create
-#     destroy_visitor_session DELETE   /visitors/sign_out(.:format)              goldencobra/sessions#destroy
-#  visitor_omniauth_authorize GET|POST /visitors/auth/:provider(.:format)        visitors/omniauth_callbacks#passthru {:provider=>/(?!)/}
-#   visitor_omniauth_callback GET|POST /visitors/auth/:action/callback(.:format) visitors/omniauth_callbacks#(?-mix:(?!))
-#            visitor_password POST     /visitors/password(.:format)              goldencobra/passwords#create
-#        new_visitor_password GET      /visitors/password/new(.:format)          goldencobra/passwords#new
-#       edit_visitor_password GET      /visitors/password/edit(.:format)         goldencobra/passwords#edit
-#                             PUT      /visitors/password(.:format)              goldencobra/passwords#update
-# cancel_visitor_registration GET      /visitors/cancel(.:format)                goldencobra/registrations#cancel
-#        visitor_registration POST     /visitors(.:format)                       goldencobra/registrations#create
-#    new_visitor_registration GET      /visitors/sign_up(.:format)               goldencobra/registrations#new
-#   edit_visitor_registration GET      /visitors/edit(.:format)                  goldencobra/registrations#edit
-#                             PUT      /visitors(.:format)                       goldencobra/registrations#update
-#                             DELETE   /visitors(.:format)                       goldencobra/registrations#destroy
-#              visitor_unlock POST     /visitors/unlock(.:format)                goldencobra/unlocks#create
-#          new_visitor_unlock GET      /visitors/unlock/new(.:format)            goldencobra/unlocks#new
-#                             GET      /visitors/unlock(.:format)                goldencobra/unlocks#show
-#                             GET      /visitors/auth/:provider(.:format)        goldencobra/omniauth_callbacks#passthru
-#                                      /*article_id.pdf(.:format)                goldencobra/articles#convert_to_pdf
-#                                      /*article_id(.:format)                    goldencobra/articles#show
-#                        root          /                                         goldencobra/articles#show {:startpage=>true}
+#                switch_language GET      /switch_language/:locale(.:format)         goldencobra/articles#switch_language
+#                frontend_logout GET      /frontend_logout/:usermodel(.:format)      goldencobra/sessions#logout
+#      manage_render_admin_menue GET      /manage/render_admin_menue(.:format)       goldencobra/manage#render_admin_menue
+#               call_for_support GET      /call_for_support(.:format)                goldencobra/manage#call_for_support
+#                 frontend_login POST     /frontend_login/:usermodel(.:format)       goldencobra/sessions#login
+#              frontend_register POST     /frontend_register/:usermodel(.:format)    goldencobra/sessions#register
+#                                POST     /manage/article_visibility/:id(.:format)   goldencobra/manage#article_visibility
+#                    sidekiq_web          /admin/background                          Sidekiq::Web
+#                  api_v1_tokens POST     /api/v1/tokens(.:format)                   goldencobra/api/v1/tokens#create
+#                   api_v1_token GET      /api/v1/tokens/:id(.:format)               goldencobra/api/v1/tokens#show
+#                api_v2_articles GET      /api/v2/articles(.:format)                 goldencobra/api/v2/articles#index
+#         api_v2_articles_search GET      /api/v2/articles/search(.:format)          goldencobra/api/v2/articles#search
+#                         api_v2 GET      /api/v2/articles/breadcrumb/*url(.:format) goldencobra/api/v2/articles#breadcrumb
+#                                GET      /api/v2/articles/*url(.:format)            goldencobra/api/v2/articles#show
+#           api_v2_locale_string GET      /api/v2/locale_string(.:format)            goldencobra/api/v2/locales#get_string
+#          api_v2_setting_string GET      /api/v2/setting_string(.:format)           goldencobra/api/v2/settings#get_string
+#                 api_v2_uploads GET      /api/v2/uploads(.:format)                  goldencobra/api/v2/uploads#index
+#         api_v2_articles_create POST     /api/v2/articles/create(.:format)          goldencobra/api/v2/articles#create
+#         api_v2_articles_update POST     /api/v2/articles/update(.:format)          goldencobra/api/v2/articles#update
+#        api_v2_navigation_menus GET      /api/v2/navigation_menus(.:format)         goldencobra/api/v2/navigation_menus#index
+# api_v2_navigation_menus_active GET      /api/v2/navigation_menus/active(.:format)  goldencobra/api/v2/navigation_menus#active_ids
+#                        sitemap GET      /sitemap(.:format)                         goldencobra/articles#sitemap {:format=>"xml"}
+#            new_visitor_session GET      /visitors/sign_in(.:format)                goldencobra/sessions#new
+#                visitor_session POST     /visitors/sign_in(.:format)                goldencobra/sessions#create
+#        destroy_visitor_session DELETE   /visitors/sign_out(.:format)               goldencobra/sessions#destroy
+#     visitor_omniauth_authorize GET|POST /visitors/auth/:provider(.:format)         visitors/omniauth_callbacks#passthru {:provider=>/(?!)/}
+#      visitor_omniauth_callback GET|POST /visitors/auth/:action/callback(.:format)  visitors/omniauth_callbacks#(?-mix:(?!))
+#               visitor_password POST     /visitors/password(.:format)               goldencobra/passwords#create
+#           new_visitor_password GET      /visitors/password/new(.:format)           goldencobra/passwords#new
+#          edit_visitor_password GET      /visitors/password/edit(.:format)          goldencobra/passwords#edit
+#                                PATCH    /visitors/password(.:format)               goldencobra/passwords#update
+#                                PUT      /visitors/password(.:format)               goldencobra/passwords#update
+#    cancel_visitor_registration GET      /visitors/cancel(.:format)                 goldencobra/registrations#cancel
+#           visitor_registration POST     /visitors(.:format)                        goldencobra/registrations#create
+#       new_visitor_registration GET      /visitors/sign_up(.:format)                goldencobra/registrations#new
+#      edit_visitor_registration GET      /visitors/edit(.:format)                   goldencobra/registrations#edit
+#                                PATCH    /visitors(.:format)                        goldencobra/registrations#update
+#                                PUT      /visitors(.:format)                        goldencobra/registrations#update
+#                                DELETE   /visitors(.:format)                        goldencobra/registrations#destroy
+#                 visitor_unlock POST     /visitors/unlock(.:format)                 goldencobra/unlocks#create
+#             new_visitor_unlock GET      /visitors/unlock/new(.:format)             goldencobra/unlocks#new
+#                                GET      /visitors/unlock(.:format)                 goldencobra/unlocks#show
+#                                GET      /visitors/auth/:provider(.:format)         goldencobra/omniauth_callbacks#passthru
+#                                GET      /*article_id(.:format)                     goldencobra/articles#show
+#                           root GET      /                                          goldencobra/articles#show {:startpage=>true}


### PR DESCRIPTION
Set menu items visibility from menu index view

- activate and deactivate menu items on menus admin index page
- click on the icon to set the menu item online or offline
- member action `member_action :activate_deactivate_menu_item`
for the logic, adapted from articles, where this functionality
was already implemented
- texts added to locale files
- latest rake routes output copied to routes, listed as comment
- Golden Cobra version upgrade from 2.0.17 to 2.0.17.1

The first commit only contains styling quotes to double quotes.
Screenshots are attached in the issue.