### PR TITLE
Removes all wkhtmltopdf and pdf gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,6 @@ PATH
       omniauth-openid
       paper_trail (~> 4.1.0)
       paperclip
-      pdfkit
       protected_attributes
       rack-utf8_sanitizer
       rails (~> 4.2.5)
@@ -72,7 +71,6 @@ PATH
       tilt
       uglifier
       whenever
-      wicked_pdf
 
 GEM
   remote: https://rubygems.org/
@@ -382,7 +380,6 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
-    pdfkit (0.8.2)
     pkg-config (1.1.7)
     pluginator (1.3.0)
     polyamorous (1.3.0)
@@ -535,7 +532,6 @@ GEM
     websocket (1.2.3)
     whenever (0.9.7)
       chronic (>= 0.6.3)
-    wicked_pdf (1.0.6)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (2.0.17)
+    goldencobra (2.0.17.1)
       actionpack-action_caching
       active_model_serializers (~> 0.9.5)
       activeadmin (~> 1.0.0.pre1)
@@ -73,7 +73,6 @@ PATH
       uglifier
       whenever
       wicked_pdf
-      wkhtmltopdf-binary
 
 GEM
   remote: https://rubygems.org/
@@ -164,7 +163,7 @@ GEM
     builder (3.2.2)
     byebug (9.0.5)
     cancan (1.6.10)
-    cancancan (1.14.0)
+    cancancan (1.15.0)
     capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
@@ -534,10 +533,9 @@ GEM
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
     websocket (1.2.3)
-    whenever (0.9.4)
+    whenever (0.9.7)
       chronic (>= 0.6.3)
     wicked_pdf (1.0.6)
-    wkhtmltopdf-binary (0.9.9.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)

--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n'
   s.add_dependency 'i18n-active_record'
   s.add_dependency 'pdfkit'
-  s.add_dependency 'wkhtmltopdf-binary'
+  # s.add_dependency 'wkhtmltopdf-binary'
   s.add_dependency 'wicked_pdf'
   s.add_dependency 'rmagick'
   s.add_dependency 'iconv'

--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -69,9 +69,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'i18n'
   s.add_dependency 'i18n-active_record'
-  s.add_dependency 'pdfkit'
-  # s.add_dependency 'wkhtmltopdf-binary'
-  s.add_dependency 'wicked_pdf'
   s.add_dependency 'rmagick'
   s.add_dependency 'iconv'
   s.add_dependency 'rack-utf8_sanitizer' # handles invalid url encodings


### PR DESCRIPTION
If you need pdf generation, please make sure to add appropriate gems to
your application. Golden Cobra no longer provides these as there were
always many conflicts with older versions of wkhtmltopdf binaries.