### PR TITLE
Don't overwrite access denied handler of host app

### DIFF
--- a/config/initializers/active_admin_devise.rb
+++ b/config/initializers/active_admin_devise.rb
@@ -1,6 +1,6 @@
 require "activeadmin"
 
-ApplicationController.class_eval do
+Goldencobra::ApplicationController.class_eval do
     layout :layout_by_resource_for_user_model
 
     def current_ability

--- a/config/initializers/active_admin_devise.rb
+++ b/config/initializers/active_admin_devise.rb
@@ -16,7 +16,7 @@ ActiveAdmin::BaseController.class_eval do
       if devise_controller? && resource_name == :user
         "goldencobra/active_admin_resque" # we emulate the active_admin layout for consistancy
       else
-        "application"
+        determine_active_admin_layout
       end
     end
 end

--- a/config/initializers/active_admin_devise.rb
+++ b/config/initializers/active_admin_devise.rb
@@ -1,6 +1,6 @@
 require "activeadmin"
 
-Goldencobra::ApplicationController.class_eval do
+ActiveAdmin::BaseController.class_eval do
     layout :layout_by_resource_for_user_model
 
     def current_ability


### PR DESCRIPTION
This initializer overwrites all settings regarding CanCan in the *host app*. With it, it was not possible to set a custom handler for "CanCan::AccessDenied" in any app using Goldencobra. Any "access denied" redirected to "/admin", which took 3 hours of digging to find this culprit.

Not sure if any of this is actually needed, GG::ApplicationController contains a similar `rescue_from`