### PR TITLE
Bug in Menübaum und Artikelbaum behoben

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /db/*.sqlite3
 
 # Ignore all logfiles and tempfiles.
+.powrc
 /log/*.log
 /tmp
 test/dummy/log/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (2.0.19)
+    goldencobra (2.0.19.4)
       actionpack-action_caching
       active_model_serializers (~> 0.9.5)
       activeadmin (~> 1.0.0.pre1)

--- a/admin/articles.rb
+++ b/admin/articles.rb
@@ -199,7 +199,7 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
   end
 
   sidebar :overview, only: [:index] do
-    #calls collection_action :load_overviewtree_as_json
+    # calls collection_action :load_overviewtree_as_json
     render partial: "/goldencobra/admin/shared/react_overview", locals: {
       object_class: "Goldencobra::Article",
       link_name: "url_name",
@@ -369,12 +369,12 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
 
   collection_action :load_overviewtree_as_json do
     if params[:root_id].present?
-      objects = Goldencobra::Article.where(id: params[:root_id]).first.children.reorder(:url_name)
+      objects = Goldencobra::Article.where(id: params[:root_id]).first.descendants.reorder(:url_name)
       cache_key ||= ["articles", params[:root_id], objects.map(&:id), objects.maximum(:updated_at)]
 
       articles = Rails.cache.fetch(cache_key) do
         Goldencobra::Article.find(params[:root_id])
-        .children.reorder(:url_name).as_json(only: [:id, :url_path, :title, :url_name],
+                            .descendants.reorder(:url_name).as_json(only: [:id, :url_path, :title, :url_name],
                                              methods: [:has_children, :restricted])
       end
     else

--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -96,11 +96,11 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
 
   collection_action :load_overviewtree_as_json do
     if params[:root_id].present?
-      objects = Goldencobra::Menue.where(id: params[:root_id]).first.children.reorder(:title)
+      objects = Goldencobra::Menue.where(id: params[:root_id]).first.descendants.reorder(:title)
       cache_key ||= ["menus", params[:root_id], objects.map(&:id), objects.maximum(:updated_at)]
 
       menus = Rails.cache.fetch(cache_key) do
-        Goldencobra::Menue.find(params[:root_id]).children.order(:title).as_json(
+        Goldencobra::Menue.find(params[:root_id]).descendants.order(:title).as_json(
           only: [:id, :target, :title],
           methods: [:has_children])
       end
@@ -109,7 +109,7 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
       cache_key ||= ["menus", objects.map(&:id), objects.maximum(:updated_at)]
 
       menus = Rails.cache.fetch(cache_key) do
-        Goldencobra::Menue.order(:title)
+        Goldencobra::Menue.reorder(:title)
           .roots.as_json(only: [:id, :target, :title], methods: [:has_children])
       end
     end

--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -84,7 +84,7 @@ module Goldencobra
     accepts_nested_attributes_for :article_widgets, allow_destroy: true
 
     acts_as_taggable_on :tags, :frontend_tags #https://github.com/mbleigh/acts-as-taggable-on
-    has_ancestry    orphan_strategy: :restrict, cache_depth: true
+    has_ancestry orphan_strategy: :restrict, cache_depth: true
 
     enum state: { void: 0, draft: 1, in_review: 2, waiting: 3, published: 4, discarded: 5 }
     web_url         :external_url_redirect

--- a/app/models/goldencobra/menue.rb
+++ b/app/models/goldencobra/menue.rb
@@ -25,7 +25,7 @@ module Goldencobra
                     :sorter, :description, :call_to_action_name, :description_title,
                     :image_attributes, :image_id, :permissions_attributes, :remote
 
-    has_ancestry orphan_strategy: :rootify, cache_depth: true
+    has_ancestry orphan_strategy: :rootify, cache_depth: true, touch: true
 
     belongs_to :image, class_name: Goldencobra::Upload, foreign_key: "image_id"
 


### PR DESCRIPTION
der Cachekey hat manchmal dafür gesorgt, das neue Elemente nicht dargestellt wurden

Der Cachkey wurde angepasst und bei den Menüs werden die Elternelemente
nun per touch aktualisiert.

Bei den Artikeln sind die Auswirkungen davon nicht absehbar,
daher wurde hier kein touch: true hinzugefügt