### PR TITLE
Artikel URLs optimiert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (2.0.19.4)
+    goldencobra (2.0.19.6)
       actionpack-action_caching
       active_model_serializers (~> 0.9.5)
       activeadmin (~> 1.0.0.pre1)

--- a/admin/article_urls.rb
+++ b/admin/article_urls.rb
@@ -1,0 +1,62 @@
+ActiveAdmin.register Goldencobra::ArticleUrl, as: "ArticleUrl" do
+  menu parent: I18n.t("settings", scope: ["active_admin","menue"]), label: I18n.t('active_admin.article_url.as'), if: proc{can?(:update, Goldencobra::ArticleUrl)}
+
+  config.clear_action_items!
+
+  form html: { enctype: "multipart/form-data" }  do |f|
+    f.actions
+      f.inputs "Einzelne Weiterleitung einrichten", class: "foldable inputs" do
+        f.input :url, as: :string, hint: "Bitte absolute Adressen angeben in der Form: http://www.von_url.de"
+        f.input :article_id, as: :number, hint: "Bitte ID des Artikels angeben"
+      end
+    f.actions
+  end
+
+  index as: :table, download_links: proc{ Goldencobra::Setting.for_key("goldencobra.backend.index.download_links") == "true" }.call do
+    selectable_column
+    column :id
+    column :url
+    column :article_id do |au|
+      link_to au.article_id, edit_admin_article_path(id: au.article_id)
+    end
+    column :created_at
+    column :updated_at
+    actions(dropdown: true)
+  end
+
+  action_item :rewrite_urls, only: [:index] do
+    link_to I18n.t('active_admin.article_url.rewrite_urls'), rewrite_urls_admin_article_urls_path()
+  end
+
+  collection_action :rewrite_urls do
+    Goldencobra::ArticleUrl.all.each do |goldencobra_article_url|
+      goldencobra_article_url.destroy
+      goldencobra_article_url.article.save
+    end
+    flash[:notice] = I18n.t('active_admin.article_url.batch_action.flash.rewrite_urls')
+    redirect_to action: :index
+  end
+
+  batch_action :rewrite_urls, "data-confirm" => I18n.t('active_admin.article_url.batch_action.flash.rewrite_urls') do |selection|
+    Goldencobra::ArticleUrl.find(selection).each do |goldencobra_article_url|
+      goldencobra_article_url.destroy
+      goldencobra_article_url.article.save
+    end
+    flash[:notice] = I18n.t('active_admin.article_url.batch_action.flash.rewrite_urls')
+    redirect_to action: :index
+  end
+
+  controller do
+    def show
+      show! do |format|
+         format.html { redirect_to edit_admin_article_url_path(@article_url.id)}
+      end
+    end
+
+    def create
+      create! do |format|
+         format.html { redirect_to admin_article_urls_path() }
+      end
+    end
+  end
+end

--- a/admin/articles.rb
+++ b/admin/articles.rb
@@ -208,7 +208,6 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
     }
   end
 
-
   sidebar :startpage_options, only: [:show, :edit] do
     if resource.startpage
       t("startpage", scope: [:goldencobra, :flash_notice])
@@ -219,6 +218,14 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
 
   sidebar "layout", only: [:edit] do
     render "/goldencobra/admin/articles/layout_sidebar", locals: { current_article: resource }
+  end
+
+  sidebar :url, only: [:edit] do
+    resource.urls.each do |article_url|
+      div link_to(article_url.url, article_url.url, target: "_blank")
+    end
+    br
+    button_to I18n.t('active_admin.article_url.batch_action.rewrite_urls'), rewrite_urls_admin_article_path(id: resource.id)
   end
 
   # Deprecated, will be removed in GC 2.1
@@ -263,6 +270,13 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
   #sidebar :help, only: [:edit, :show] do
   #  render "/goldencobra/admin/shared/help"
   #end
+
+  member_action :rewrite_urls, method: :post do
+    article = Goldencobra::Article.find_by_id(params[:id])
+    article.urls.destroy_all
+    article.save
+    redirect_to action: :edit
+  end
 
   member_action :change_articletype, method: :post do
     article = Goldencobra::Article.find(params[:id])

--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -572,7 +572,9 @@ module Goldencobra
     #
     # @return [boolean] Goldencobra::AricleUrl.setup() response
     def update_article_urls
-      if previous_changes["startpage"] || previous_changes["url_path"] || previous_changes["url_name"] || previous_changes["ancestry"]
+      if previous_changes["startpage"] || previous_changes["url_path"] ||
+         previous_changes["url_name"] || previous_changes["ancestry"] ||
+         urls.blank?
         Goldencobra::ArticleUrl.setup(id)
       end
     end

--- a/config/locales/active_admin.de.yml
+++ b/config/locales/active_admin.de.yml
@@ -46,6 +46,13 @@ de:
   active_admin:
     redirector:
       as: "Weiterleitungen"
+    article_url:
+      rewrite_urls: "Alle Urls neu erzeugen"
+      batch_action:
+        rewrite_urls: "URL neu erzeugen"
+        flash:
+          rewrite_urls: "URLs wurden neu erzeugt"
+      as: "Artikel URLs"
     dashboard: Übersicht
     dashboard_welcome:
       welcome: "Willkommen in Active Admin. Dies ist die Standard-Übersichtsseite."

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -46,6 +46,13 @@ en:
   active_admin:
     redirector:
       as: "Redirections"
+    article_url:
+      rewrite_urls: "Regenerate all urls"
+      batch_action:
+        rewrite_urls: "regenerate url"
+        flash:
+          rewrite_urls: "URLs regenerated"
+      as: "Article URLs"
     dashboard: "Dashboard"
     dashboard_welcome:
       welcome: "Welcome to Active Admin. This is the standard dashboard page."


### PR DESCRIPTION
- es gibt nun im Backend eine Liste aller ArtikelURLS
- beim Artikel wird in der Seitenleiste die URL angezeigt
- URLs können regeneriert werden
- beim Speichern des Artikels wird nun zusätzlich geprüft,
  ob es bereits eine URL gibt und im Zweifel eine erzeugt

JIRA-TASK: GCZ-74

![bildschirmfoto 2016-10-06 um 10 58 17](https://cloud.githubusercontent.com/assets/90779/19146599/78a060fe-8bb4-11e6-98bf-13f684029057.jpg)

![bildschirmfoto 2016-10-06 um 10 32 22](https://cloud.githubusercontent.com/assets/90779/19146620/8bb87974-8bb4-11e6-9ba6-729d3e031801.jpg)

![bildschirmfoto 2016-10-06 um 10 51 31](https://cloud.githubusercontent.com/assets/90779/19146638/a61769e2-8bb4-11e6-85ac-c533b4c66048.jpg)
