### PR TITLE
Rewrite php format route constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PATH
       inherited_resources
       jquery-rails
       json
-      liquid
+      liquid (= 3.0.6)
       meta-tags
       oa-oauth
       oa-openid
@@ -131,7 +131,7 @@ GEM
     acts-as-taggable-on (4.0.0)
       activerecord (>= 4.0)
     addressable (2.4.0)
-    ancestry (2.2.2)
+    ancestry (2.1.0)
       activerecord (>= 3.0.0)
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
@@ -139,7 +139,7 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (6.0.3)
-    autoprefixer-rails (6.5.3)
+    autoprefixer-rails (6.4.1.1)
       execjs
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -177,7 +177,7 @@ GEM
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    chunky_png (1.3.8)
+    chunky_png (1.3.7)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.8)
@@ -207,7 +207,7 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.0.2)
-    connection_pool (2.2.1)
+    connection_pool (2.2.0)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -251,7 +251,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
-    font-awesome-sass (4.7.0)
+    font-awesome-sass (4.6.2)
       sass (>= 3.2)
     formatador (0.2.5)
     formtastic (3.1.4)
@@ -364,7 +364,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (2.17.5)
+    oj (2.17.4)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -450,7 +450,7 @@ GEM
       railties (>= 3.2)
       tilt
     redcarpet (3.3.4)
-    redis (3.3.2)
+    redis (3.3.1)
     remove_accents (0.0.2)
     request_store (1.3.1)
     responders (2.3.0)
@@ -493,10 +493,10 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    sidekiq (4.2.6)
+    sidekiq (4.2.1)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
-      rack-protection (>= 1.5.0)
+      rack-protection (~> 1.5)
       redis (~> 3.2, >= 3.2.1)
     simple_enum (2.3.0)
       activesupport (>= 4.0.0)
@@ -523,7 +523,7 @@ GEM
     tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.3)
+    uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
     warden (1.2.6)
       rack (>= 1.0)
@@ -590,4 +590,4 @@ DEPENDENCIES
   yarjuf
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,10 +40,8 @@ Goldencobra::Engine.routes.draw do
   end
 
   # match "/*article_id.pdf", to: "articles#convert_to_pdf"
-  get "/*article_id", to: "articles#show", constraints: lambda { |req|
-    # php requests results in MimeType:Null-Object Github #47
-    !["php", ""].include?(req.format.to_sym.to_s.downcase)
-  }
+  # php requests results in MimeType:Null-Object Github #47
+  get "/*article_id", to: "articles#show", constraints: lambda { |req| req.format.php != :php }
 
   root to: "articles#show", defaults: { startpage: true }
 end


### PR DESCRIPTION
There was a big problem, where almost(?) all urls below the startpage
triggered a 404 when curl'ed or shared with Facebook. The reason lay in
the routes, esp. in the constraints where we try to filter the requests
that have a format like :php.