### PR TITLE
Gracefully handle 404 responses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (2.0.23)
+    goldencobra (2.0.24)
       actionpack-action_caching
       active_model_serializers (~> 0.9.5)
       activeadmin (~> 1.0.0.pre1)
@@ -590,4 +590,4 @@ DEPENDENCIES
   yarjuf
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/app/controllers/goldencobra/articles_controller.rb
+++ b/app/controllers/goldencobra/articles_controller.rb
@@ -165,9 +165,10 @@ module Goldencobra
       if @article
         respond_to do |format|
           format.html { render layout: @article.selected_layout, status: 404 }
+          format.any { head(status: 404) }
         end
       else
-        render text: "404", status: 404
+        head(status: 404)
       end
     end
 

--- a/test/dummy/spec/controllers/articles_controller_spec.rb
+++ b/test/dummy/spec/controllers/articles_controller_spec.rb
@@ -278,6 +278,82 @@ describe Goldencobra::ArticlesController, type: :controller do
       expect(response.status).to eq(404)
     end
 
+    context "the resource isn't found" do
+      context "the format != :html" do
+        context "the '404' article exists" do
+          before(:each) do
+            Goldencobra::Article.create!(
+              title: "404",
+              url_name: "404",
+              breadcrumb: "404",
+              article_type: "Default Show"
+            )
+          end
+
+          it "respond with a 404 status" do
+            get :show, { format: "application/xml" }
+
+            expect(response.status).to eq(404)
+          end
+
+          it "respond with a 404 status" do
+            get :show, { format: "application/json" }
+
+            expect(response.status).to eq(404)
+          end
+        end
+
+        context "the '404' article does not exists" do
+          before(:each) do
+            expect(Goldencobra::Article.find_by_url_name("404")).to eq(nil)
+          end
+
+          it "respond with a 404 status" do
+            get :show, { format: "application/xml" }
+
+            expect(response.status).to eq(404)
+          end
+
+          it "respond with a 404 status" do
+            get :show, { format: "application/json" }
+
+            expect(response.status).to eq(404)
+          end
+        end
+      end
+
+      context "the format == :html" do
+        context "the '404' article exists" do
+          before(:each) do
+            Goldencobra::Article.create!(
+              title: "404",
+              url_name: "404",
+              breadcrumb: "404",
+              article_type: "Default Show"
+            )
+          end
+
+          it "respond with a 404 status" do
+            get :show, { format: :html }
+
+            expect(response.status).to eq(404)
+          end
+        end
+
+        context "the '404' article does not exists" do
+          before(:each) do
+            expect(Goldencobra::Article.find_by_url_name("404")).to eq(nil)
+          end
+
+          it "respond with a 404 status" do
+            get :show, { format: :html }
+
+            expect(response.status).to eq(404)
+          end
+        end
+      end
+    end
+
     context "with a valid format" do
       before do
         Goldencobra::Article.create(title: "Mein Artikel", url_name: "mein-artikel")


### PR DESCRIPTION
Bots, maliciously acting people and many other 'things' request routes
in our Rails apps, that are simply not supported. Because we have a
'catch-all' route in Golden Cobra, we have to make sure these requests
aren't routed to existing controllers. For this purpose we ignore the
format `:php` through a "route constraint".
Some other requests are still passed to the
`Goldencobra::ArticlesController` though. These might have the format
`:xml` or something similar, that we generally accept. Now we have to
make sure, that we send the correct response if the resource isn't
found.

For that purpose we use `format.any { head(status: 404) }` inside our
`redirect_to_404` method. Up until now there was only a `respond_to`
block for the `format.html` case. If the request has the format `:html`
we continue to serve our (custom) 404 article/page. If the request is of
a different format, we kept receiving `ActionController::UnknownFormat:
ActionController::UnknownFormat` errors. This new format block will
prevent this error from happening. Just respond with a "HEAD 404"
response is enough for these cases.