### PR TITLE
Share sessions between Rails and Sinatra

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (2.0.25)
+    goldencobra (2.0.26)
       actionpack-action_caching
       active_model_serializers (~> 0.9.5)
       activeadmin (~> 1.0.0.pre1)
@@ -442,7 +442,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    react-rails (1.9.0)
+    react-rails (1.8.2)
       babel-transpiler (>= 0.7.0)
       coffee-script-source (~> 1.8)
       connection_pool
@@ -455,7 +455,7 @@ GEM
     request_store (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    rmagick (2.16.0)
+    rmagick (2.15.4)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)

--- a/config/initializers/sidekiq.rb.tmpl
+++ b/config/initializers/sidekiq.rb.tmpl
@@ -5,3 +5,4 @@ end
 Sidekiq.configure_server do |config|
   config.redis = { url: 'redis://redis:6379/0', namespace: 'sidekiq_goldencobra' }
 end
+

--- a/config/initializers/sidekiq_web.rb
+++ b/config/initializers/sidekiq_web.rb
@@ -1,0 +1,7 @@
+if RUBY_VERSION.to_f >= 1.9
+  require "sidekiq/web"
+  # Make Sinatra and Rails share a session to prevent CSRF errors when using Sidekiq web
+  # interface: https://github.com/mperham/sidekiq/issues/1289#issuecomment-232330804
+  Sidekiq::Web.set(:session_secret, Rails.application.secrets[:secret_key_base])
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
-require "sidekiq/web" if RUBY_VERSION.to_f >= 1.9
-
 Goldencobra::Engine.routes.draw do
   get "switch_language/:locale"        => "articles#switch_language", as: :switch_language
   get "frontend_logout/:usermodel"     => "sessions#logout", as: :frontend_logout


### PR DESCRIPTION
Sinatra, if given no secret for cookie session storage, generates a
random one as the server starts. So I end up with different secrets on
different app instances and cookies signed on one instance are not
recognized on other one, which leads to new session with new csrf token,
which does not match authenticity token anymore

This commit is based on the discussion in
https://github.com/mperham/sidekiq/issues/1289 regarding this problem.
The comment in https://github.com/mperham/sidekiq/issues/1289#issuecomment-232330804 seems to fix the issue for most people so I hope it does work for Goldencobra as well. Perhaps there is still some setting in nginx to be done. We'll see.

If everything works we should be able to click "Retry all" and similar
buttons in the Sidekiq webinterface w/o getting the "Forbidden" error
page.