### PR TITLE
Remove devise and devise-token_authenticatable fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (2.0.25)
+    goldencobra (2.0.26)
       actionpack-action_caching
       active_model_serializers (~> 0.9.5)
       activeadmin (~> 1.0.0.pre1)
@@ -32,8 +32,8 @@ PATH
       cancancan
       compass
       compass-rails
-      devise (~> 3.5.2)
-      devise-token_authenticatable (= 0.4.6)
+      devise
+      devise-token_authenticatable
       exception_notification
       font-awesome-sass
       geocoder
@@ -590,4 +590,4 @@ DEPENDENCIES
   yarjuf
 
 BUNDLED WITH
-   1.13.7
+   1.14.2

--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
   # s.add_dependency 'coffee-script-source', '~>1.8.0'
   s.add_dependency "rails", "~> 4.2.5"
   s.add_dependency "jquery-rails"
-  s.add_dependency "devise", "~> 3.5.2"
-  s.add_dependency "devise-token_authenticatable", "0.4.6"
+  s.add_dependency "devise"
+  s.add_dependency "devise-token_authenticatable"
   # TODO: Token Authentication neu machen
   s.add_dependency "cancancan"
   s.add_dependency "activeadmin", "~> 1.0.0.pre1"


### PR DESCRIPTION
The versions are no longer fixed in the gemspec.