### PR TITLE
Shorten cache key generation for over-view tree

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1093,6 +1093,16 @@ Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 10
 
+Metrics/BlockLength:
+  CountComments: false  # count full line comments?
+  Max: 25
+  ExcludedMethods: ["describe", "context", "ActiveAdmin"]
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+    - 'admin/**.rb'
+
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: true


### PR DESCRIPTION
The generation of the cache key lead to an `ENAMETOOLONG` error:
```
Errno::ENAMETOOLONG - File name too long @ rb_file_s_stat
```

If we use the the `#hash` method of Strings we can prevent this from
happening. The hashed strings are still random enough for the cache to
work properly.

There is a minor concern with this method:

> The hash value for an object may not be identical across invocations
or implementations of Ruby. If you need a stable identifier across Ruby
invocations and implementations you will need to generate one with a
custom method.

But in practice this shouldn't really be an issue. Even if the cache is
missed because the key generated does not exist in this invocation, the
cache contents will just be regenerated.

Fixes #74