### PR TITLE
Prevent CORS errors for malicious requests

### DIFF
--- a/app/controllers/goldencobra/articles_controller.rb
+++ b/app/controllers/goldencobra/articles_controller.rb
@@ -60,7 +60,10 @@ module Goldencobra
             format.html { render layout: choose_layout }
             format.rss
             format.json do
-              render json: { article: @article.to_json, list_of_articles: @list_of_articles.as_json }
+              render json: {
+                article: @article.to_json,
+                list_of_articles: @list_of_articles.as_json
+              }
             end
           end
         end

--- a/app/controllers/goldencobra/articles_controller.rb
+++ b/app/controllers/goldencobra/articles_controller.rb
@@ -7,7 +7,7 @@ module Goldencobra
     # for our app => ActionController::InvalidCrossOriginRequest. To prevent these errors, we have
     # to disable the protection from forgery, for the :show action. The app will respond with a 404
     # status for all these requests.
-    protect_from_forgery except: :show
+    # protect_from_forgery except: :show
 
     layout "application"
     before_filter :get_redirectors, only: [:show]
@@ -68,8 +68,7 @@ module Goldencobra
             format.html { render layout: choose_layout }
             format.rss
             format.json do
-              @article["list_of_articles"] = @list_of_articles
-              render json: @article.to_json
+              render json: {article: @article.to_json, list_of_articles: @list_of_articles.as_json}
             end
           end
         end

--- a/app/controllers/goldencobra/articles_controller.rb
+++ b/app/controllers/goldencobra/articles_controller.rb
@@ -1,5 +1,13 @@
 module Goldencobra
   class ArticlesController < Goldencobra::ApplicationController
+    # Sometimes the host app get requests like this: "/wp-admin/js/media-upload.dev.js"
+    # These request originate from bots that might be malicious and crawl sites for wordpress' weak
+    # spots. Since we have the catch all routes for articles in out engine, we try to respond to
+    # these requests. As the format of the request is "text/javascript", this triggers a CORS error
+    # for our app => ActionController::InvalidCrossOriginRequest. To prevent these errors, we have
+    # to disable the protection from forgery, for the :show action. The app will respond with a 404
+    # status for all these requests.
+    protect_from_forgery except: :show
 
     layout "application"
     before_filter :get_redirectors, only: [:show]

--- a/app/controllers/goldencobra/articles_controller.rb
+++ b/app/controllers/goldencobra/articles_controller.rb
@@ -1,13 +1,5 @@
 module Goldencobra
   class ArticlesController < Goldencobra::ApplicationController
-    # Sometimes the host app get requests like this: "/wp-admin/js/media-upload.dev.js"
-    # These request originate from bots that might be malicious and crawl sites for wordpress' weak
-    # spots. Since we have the catch all routes for articles in out engine, we try to respond to
-    # these requests. As the format of the request is "text/javascript", this triggers a CORS error
-    # for our app => ActionController::InvalidCrossOriginRequest. To prevent these errors, we have
-    # to disable the protection from forgery, for the :show action. The app will respond with a 404
-    # status for all these requests.
-    # protect_from_forgery except: :show
 
     layout "application"
     before_filter :get_redirectors, only: [:show]
@@ -68,7 +60,7 @@ module Goldencobra
             format.html { render layout: choose_layout }
             format.rss
             format.json do
-              render json: {article: @article.to_json, list_of_articles: @list_of_articles.as_json}
+              render json: { article: @article.to_json, list_of_articles: @list_of_articles.as_json }
             end
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,8 @@ Goldencobra::Engine.routes.draw do
 
   # match "/*article_id.pdf", to: "articles#convert_to_pdf"
   # php requests results in MimeType:Null-Object Github #47
-  get "/*article_id", to: "articles#show", constraints: lambda { |req| req.format.to_sym != :php }
+  get "/*article_id", to: "articles#show", constraints: lambda { |req| req.format.to_sym != :php && req.format.to_sym != :js }
+  get '/*path', to: redirect("/404")
 
   root to: "articles#show", defaults: { startpage: true }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,9 +40,12 @@ Goldencobra::Engine.routes.draw do
   end
 
   # match "/*article_id.pdf", to: "articles#convert_to_pdf"
+
   # php requests results in MimeType:Null-Object Github #47
-  get "/*article_id", to: "articles#show", constraints: lambda { |req| req.format.to_sym != :php && req.format.to_sym != :js }
-  get '/*path', to: redirect("/404")
+  get "/*article_id",
+      to: "articles#show",
+      constraints: ->(req) { req.format.to_sym != :php && req.format.to_sym != :js }
+  get "/*path", to: redirect("/404")
 
   root to: "articles#show", defaults: { startpage: true }
 end

--- a/test/dummy/spec/controllers/articles_controller_spec.rb
+++ b/test/dummy/spec/controllers/articles_controller_spec.rb
@@ -271,6 +271,12 @@ describe Goldencobra::ArticlesController, type: :controller do
       end
     end
 
+    context "JS Request are not causeing a ActionController::InvalidCrossOriginRequest"
+    it "respond with a 404 Page on js request" do
+      visit "/no_article_found.js"
+      expect(response.status).to eq(200)
+    end
+
     context "the resource isn't found" do
       context "the format != :html" do
         context "the '404' article exists" do

--- a/test/dummy/spec/controllers/articles_controller_spec.rb
+++ b/test/dummy/spec/controllers/articles_controller_spec.rb
@@ -261,10 +261,12 @@ describe Goldencobra::ArticlesController, type: :controller do
 
   describe "#show" do
 
-    it "renders 404 if request.format is php" do
-      get :show, { format: "application/php" }
+    ["application/php", "text/javascript"].each do |format|
+      it "renders 404" do
+        get :show, { format: format }
 
-      expect(response.status).to eq(404)
+        expect(response.status).to eq(404)
+      end
     end
 
     context "the resource isn't found" do

--- a/test/dummy/spec/controllers/articles_controller_spec.rb
+++ b/test/dummy/spec/controllers/articles_controller_spec.rb
@@ -39,63 +39,65 @@ describe Goldencobra::ArticlesController, type: :controller do
     context 'as an admin' do
       it "should be possible to read a secured article as a preview function" do
         create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", subject_id: @parent_article.id.to_s, :role_id => @admin_role.id, :sorter_id => 200
-        sign_in(:user, @user)
+        sign_in(@user, scope: :user)
         visit "#{@parent_article.public_url}?auth_token=#{@user.authentication_token}"
         expect(page).to have_content(@parent_article.title)
       end
 
       it "should be possible to read an article" do
         visit "/admin/logout"
-        sign_in(:user, @user)
+        sign_in(@user, scope: :user)
         visit "#{@parent_article.public_url}?auth_token=#{@user.authentication_token}"
         expect(page).to have_content(@parent_article.title)
       end
 
       it 'should return 404 if no article is found' do
-        sign_in(:user, @user)
+        create(:article, title: "404", url_name: "404", content: "404")
+        sign_in(@user, scope: :user)
         visit "/no_article?auth_token=#{@user.authentication_token}"
-        expect(page).to have_content('404')
+        expect(response.status).to eq(404)
+        expect(response.body).to have_content("404")
       end
     end
 
     context 'as a visitor' do
       it "should be possible to read an article" do
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         visit @parent_article.public_url
         expect(page).to have_content(@parent_article.title)
       end
 
       it "should not be possible to read a secured article as a visitor" do
         create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", :sorter_id => 200, :subject_id => @parent_article.id
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         visit @parent_article.public_url
         expect(page).to have_content("Nicht authorisiert")
       end
 
       it "should not be possible to read a secured article for a domain if i am on this domain" do
         create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", :sorter_id => 200, :subject_id => @parent_article.id, :domain_id => @domain_access.id
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         visit @parent_article.public_url
         expect(page).to have_content("Nicht authorisiert")
       end
 
       it "should be possible to read a secured article for a domain if it's locked for another domain" do
         create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", :sorter_id => 200, :subject_id => @parent_article.id, :domain_id => @domain_restricted.id
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         visit @parent_article.public_url
         expect(page).to have_content(@parent_article.title)
       end
 
       it "should not be possible to read a secured article for a domain if I am on this domain with a role" do
         create :permission, action: "not_read", subject_class: "Goldencobra::Article", sorter_id: 200, subject_id: @parent_article.id, domain_id: @domain_access.id, role_id: @guest_role.id
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         visit @parent_article.public_url
         # expect(page).to have_content("Nicht authorisiert")
       end
 
       it "should be possible to read a secured article for a domain if it's locked for another domain with a role" do
         create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", :sorter_id => 200, :subject_id => @parent_article.id, :domain_id => @domain_restricted.id, :role_id => @guest_role.id
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         visit @parent_article.public_url
         expect(page).to have_content(@parent_article.title)
       end
@@ -111,7 +113,7 @@ describe Goldencobra::ArticlesController, type: :controller do
       end
 
       it "should not be possible to read an article with secured parent article" do
-        sign_in(:visitor, @visitor)
+        sign_in(@visitor, scope: :visitor)
         create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", :role_id => @guest_role.id, :sorter_id => 200, :subject_id => @parent_article.id
         visit "#{@child_article.public_url}?auth_token=#{@visitor.authentication_token}"
         expect(page).to have_content("Nicht authorisiert")
@@ -243,7 +245,7 @@ describe Goldencobra::ArticlesController, type: :controller do
 
       context 'when logged in as a admin' do
         it "should give a complete rss feed" do
-          sign_in(:user, @user)
+          sign_in(@user, scope: :user)
           child2 = Goldencobra::Article.where(url_name: "child-article-2").first
           create :permission, :action => "not_read", :subject_class => "Goldencobra::Article", :sorter_id => 200, :subject_id => child2.id
           create :permission, :action => "read", :subject_class => "Goldencobra::Article", :sorter_id => 220, :subject_id => child2.id, role_id: @guest_role.id

--- a/test/dummy/spec/models/redirector_spec.rb
+++ b/test/dummy/spec/models/redirector_spec.rb
@@ -13,12 +13,12 @@ describe Goldencobra::Redirector do
 
   describe 'if url includes üöä' do
     before(:each) do
-      Goldencobra::Setting.set_value_for_key("http://www.google.de", 
-                                             "goldencobra.url", 
+      Goldencobra::Setting.set_value_for_key("http://www.google.de",
+                                             "goldencobra.url",
                                              data_type_name="string")
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiteröleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiteröleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
     end
 
@@ -31,9 +31,9 @@ describe Goldencobra::Redirector do
   describe 'if ignore_url_params is true without url params' do
     before(:each) do
       Goldencobra::Setting.set_value_for_key("http://www.google.de", "goldencobra.url", data_type_name="string")
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
     end
 
@@ -67,12 +67,12 @@ describe Goldencobra::Redirector do
 
   describe 'if ignore_url_params is true with url params on target' do
     before(:each) do
-      Goldencobra::Setting.set_value_for_key("http://www.google.de", 
-                                             "goldencobra.url", 
+      Goldencobra::Setting.set_value_for_key("http://www.google.de",
+                                             "goldencobra.url",
                                              data_type_name="string")
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.yourdomain.de/weiterleitung?test=123", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.yourdomain.de/weiterleitung?test=123",
+                                     ignore_url_params: true,
                                      active: true)
     end
 
@@ -95,12 +95,12 @@ describe Goldencobra::Redirector do
 
   describe 'if ignore_url_params is true with url params on source' do
     before(:each) do
-      Goldencobra::Setting.set_value_for_key("http://www.google.de", 
+      Goldencobra::Setting.set_value_for_key("http://www.google.de",
                                              "goldencobra.url",
                                              data_type_name="string")
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
     end
 
@@ -139,61 +139,61 @@ describe Goldencobra::Redirector do
   describe 'more URL variants' do
 
     before do
-      Goldencobra::Setting.set_value_for_key("http://www.google.de", 
-                                             "goldencobra.url", 
+      Goldencobra::Setting.set_value_for_key("http://www.google.de",
+                                             "goldencobra.url",
                                              data_type_name="string")
     end
     #no url params given or set
     #ignore_url_params = true
     it "should not redirect on different url" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/not_to_redirect?test=2")
       expect(redirector).to eq nil
     end
 
     it "should not redirect on similar but different url" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiter?test=2")
       expect(redirector).to eq nil
     end
 
     it "should not redirect on similar but different url" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitungen?test=2")
       expect(redirector).to eq nil
     end
 
     it "should redirect on same url" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitung?test=2")
       expect(redirector).to eq ["http://www.google.de?test=2", 301]
     end
 
     it "should not redirect on same url with and a given subdir" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitung/test?test=2")
       expect(redirector).to eq nil
     end
 
     it "should redirect on same url with url params" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: true, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: true,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitung?test=1&foo=bar")
       expect(redirector).to eq ["http://www.google.de?foo=bar&test=1", 301]
@@ -201,27 +201,27 @@ describe Goldencobra::Redirector do
 
 
     it "should redirect on same url with url params" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: false, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: false,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitung?test=1")
       expect(redirector).to eq ["http://www.google.de?test=1", 301]
     end
 
     it "should not redirect on same url with url params" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: false, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: false,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitung?test=2")
       expect(redirector).to eq nil
     end
 
     it "should not redirect on same url with url params" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1", 
-                                     target_url: "www.google.de", 
-                                     ignore_url_params: false, 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1",
+                                     target_url: "www.google.de",
+                                     ignore_url_params: false,
                                      active: true)
       redirector = Goldencobra::Redirector.get_by_request("http://www.yourdomain.de/weiterleitung?foo=1")
       expect(redirector).to eq nil
@@ -237,7 +237,7 @@ describe Goldencobra::Redirector do
     end
 
     it "should redirect on same url with url params" do
-      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1", 
+      Goldencobra::Redirector.create(source_url: "www.yourdomain.de/weiterleitung?test=1",
                                      target_url: "www.google.de",
                                      ignore_url_params: false,
                                      active: true)
@@ -259,34 +259,34 @@ describe Goldencobra::Redirector do
   describe 'if an article is modified, a redirection should be created' do
     before(:each) do
       Goldencobra::Setting.set_value_for_key("http://www.goldencobra.de", "goldencobra.url")
-      @root = Goldencobra::Article.create(url_name: "startseite", 
-                                          breadcrumb: "Startseite", 
-                                          title: "Startseite", 
+      @root = Goldencobra::Article.create(url_name: "startseite",
+                                          breadcrumb: "Startseite",
+                                          title: "Startseite",
                                           article_type: "Default Show")
       @root.mark_as_startpage!
-      @seite1 = Goldencobra::Article.create(url_name: "seite1", 
+      @seite1 = Goldencobra::Article.create(url_name: "seite1",
                                             breadcrumb: "Seite1",
-                                            title: "Seite1", 
-                                            article_type: "Default Show", 
-                                            parent: @root, 
+                                            title: "Seite1",
+                                            article_type: "Default Show",
+                                            parent: @root,
                                             created_at: (Time.now - 25.hours))
-      @seite2 = Goldencobra::Article.create(url_name: "seite2", 
+      @seite2 = Goldencobra::Article.create(url_name: "seite2",
                                             breadcrumb: "Seite2",
-                                            title: "Seite2", 
-                                            article_type: "Default Show", 
-                                            parent: @seite1, 
+                                            title: "Seite2",
+                                            article_type: "Default Show",
+                                            parent: @seite1,
                                             created_at: (Time.now - 25.hours))
-      @seite3 = Goldencobra::Article.create(url_name: "seite3", 
+      @seite3 = Goldencobra::Article.create(url_name: "seite3",
                                             breadcrumb: "Seite3",
-                                            title: "Seite3", 
-                                            article_type: "Default Show", 
-                                            parent: @seite1, 
+                                            title: "Seite3",
+                                            article_type: "Default Show",
+                                            parent: @seite1,
                                             created_at: (Time.now - 25.hours))
-      @seite4 = Goldencobra::Article.create(url_name: "seite4", 
+      @seite4 = Goldencobra::Article.create(url_name: "seite4",
                                             breadcrumb: "Seite4",
-                                            title: "Seite4", 
-                                            article_type: "Default Show", 
-                                            parent: @seite3, 
+                                            title: "Seite4",
+                                            article_type: "Default Show",
+                                            parent: @seite3,
                                             created_at: (Time.now - 25.hours))
     end
 
@@ -297,78 +297,78 @@ describe Goldencobra::Redirector do
     end
 
     it "if url_name changed" do
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite3"
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite3"
       @seite3.url_name = "neue_seite3"
       @seite3.save
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/neue_seite3"
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3", target_url: "http://www.goldencobra.de/seite1/neue_seite3", active: true).count).to eq 1
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/neue_seite3"
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3", target_url: "#{Goldencobra::Url}/seite1/neue_seite3", active: true).count).to eq 1
     end
 
     it "if parent/ancestry changed for self" do
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite3"
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite3"
       @seite3.parent = @seite2
       @seite3.save
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite2/seite3"
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3", target_url: "http://www.goldencobra.de/seite1/seite2/seite3", active: true).count).to eq 1
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite2/seite3"
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3", target_url: "#{Goldencobra::Url}/seite1/seite2/seite3", active: true).count).to eq 1
     end
 
     it "if parent/ancestry changed for self and url_name changed" do
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite3"
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite3"
       @seite3.url_name = "neue_seite3"
       @seite3.parent = @seite2
       @seite3.save
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite2/neue_seite3"
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3", target_url: "http://www.goldencobra.de/seite1/seite2/neue_seite3", active: true).count).to eq 1
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite2/neue_seite3"
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3", target_url: "#{Goldencobra::Url}/seite1/seite2/neue_seite3", active: true).count).to eq 1
     end
 
     it "if parent/ancestry changed and url_name for childrens" do
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite3"
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite3"
       @seite3.parent = @seite2
       @seite3.url_name = "neue_seite3"
       @seite3.save
-      expect(@seite3.absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite2/neue_seite3"
+      expect(@seite3.absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite2/neue_seite3"
 
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3", target_url: "http://www.goldencobra.de/seite1/seite2/neue_seite3", active: true).count).to eq 1
-      
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3", target_url: "#{Goldencobra::Url}/seite1/seite2/neue_seite3", active: true).count).to eq 1
+
       #folgendes wäre ideal:
       #expect(Goldencobra::Redirector.where(:source_url => "http://www.goldencobra.de/seite1/seite3/seite4", :target_url => "http://www.goldencobra.de/seite1/seite2/neue_seite3/seite4", :active => true).count).to eq 1
-      
+
       #Geht auch ist aber nicht ganz so schön:
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3/seite4", target_url: "http://www.goldencobra.de/seite1/seite2/seite3/seite4", active: true).count).to eq 1
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite2/seite3/seite4", target_url: "http://www.goldencobra.de/seite1/seite2/neue_seite3/seite4", active: true).count).to eq 1
-      
-      expect(Goldencobra::Article.find_by_id(@seite3.id).absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite2/neue_seite3"
-      expect(Goldencobra::Article.find_by_id(@seite4.id).absolute_public_url).to eq "http://www.goldencobra.de/seite1/seite2/neue_seite3/seite4"
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3/seite4", target_url: "#{Goldencobra::Url}/seite1/seite2/seite3/seite4", active: true).count).to eq 1
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite2/seite3/seite4", target_url: "#{Goldencobra::Url}/seite1/seite2/neue_seite3/seite4", active: true).count).to eq 1
+
+      expect(Goldencobra::Article.find_by_id(@seite3.id).absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite2/neue_seite3"
+      expect(Goldencobra::Article.find_by_id(@seite4.id).absolute_public_url).to eq "#{Goldencobra::Url}/seite1/seite2/neue_seite3/seite4"
     end
 
 
     it "if parent changed for childrens" do
-      expect(@seite1.absolute_public_url).to eq "http://www.goldencobra.de/seite1"
+      expect(@seite1.absolute_public_url).to eq "#{Goldencobra::Url}/seite1"
       @seite1.url_name = "neue_seite1"
       @seite1.save
-      expect(@seite1.absolute_public_url).to eq "http://www.goldencobra.de/neue_seite1"
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1",
-                                           target_url: "http://www.goldencobra.de/neue_seite1",
+      expect(@seite1.absolute_public_url).to eq "#{Goldencobra::Url}/neue_seite1"
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1",
+                                           target_url: "#{Goldencobra::Url}/neue_seite1",
                                            active: true).count).to eq 1
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3",
-                                           target_url: "http://www.goldencobra.de/neue_seite1/seite3",
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3",
+                                           target_url: "#{Goldencobra::Url}/neue_seite1/seite3",
                                            active: true).count).to eq 1
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/seite1/seite3/seite4",
-                                           target_url: "http://www.goldencobra.de/neue_seite1/seite3/seite4",
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/seite1/seite3/seite4",
+                                           target_url: "#{Goldencobra::Url}/neue_seite1/seite3/seite4",
                                            active: true).count).to eq 1
-      expect(Goldencobra::Article.find_by_id(@seite3.id).absolute_public_url).to eq "http://www.goldencobra.de/neue_seite1/seite3"
-      expect(Goldencobra::Article.find_by_id(@seite4.id).absolute_public_url).to eq "http://www.goldencobra.de/neue_seite1/seite3/seite4"
+      expect(Goldencobra::Article.find_by_id(@seite3.id).absolute_public_url).to eq "#{Goldencobra::Url}/neue_seite1/seite3"
+      expect(Goldencobra::Article.find_by_id(@seite4.id).absolute_public_url).to eq "#{Goldencobra::Url}/neue_seite1/seite3/seite4"
     end
 
     it "not if new article is created on existing redirection source_url" do
-      Goldencobra::Redirector.create(source_url: "http://www.goldencobra.de/neue_seite1",
-                                     target_url: "http://www.goldencobra.de/neue_seite2")
+      Goldencobra::Redirector.create(source_url: "#{Goldencobra::Url}/neue_seite1",
+                                     target_url: "#{Goldencobra::Url}/neue_seite2")
       Goldencobra::Article.create(url_name: "neue_seite1",
                                   breadcrumb: "Neue Seite1",
                                   title: "Neue Seite1",
                                   article_type: "Default Show",
                                   parent: @root)
-      expect(Goldencobra::Redirector.where(source_url: "http://www.goldencobra.de/neue_seite1",
+      expect(Goldencobra::Redirector.where(source_url: "#{Goldencobra::Url}/neue_seite1",
                                            active: true).count).to eq 0
     end
 

--- a/test/dummy/spec/spec_helper.rb
+++ b/test/dummy/spec/spec_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   #config.infer_base_class_for_anonymous_controllers = false
 
   # Add this line if you use Devise for authentication:
-  config.include Devise::TestHelpers, :type => :controller
+  config.include Devise::Test::ControllerHelpers, :type => :controller
   config.include Capybara::DSL
 end
 


### PR DESCRIPTION
Sometimes the host app get requests like this:
"/wp-admin/js/media-upload.dev.js". These request originate from bots
that might be malicious and crawl sites for wordpress' weak spots. Since
we have the catch all routes for articles in out engine, we try to
respond to these requests. As the format of the request is
"text/javascript", this triggers a CORS error for our app =>
ActionController::InvalidCrossOriginRequest. To prevent these errors, we
have to disable the protection from forgery, for the :show action. The
app will respond with a 404 status for all these requests.

GCZ-84