### PR TITLE
Use strings for OJ hash keys

### DIFF
--- a/admin/articles.rb
+++ b/admin/articles.rb
@@ -404,7 +404,24 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
         )
       end
     end
+
+    # The commit fcc35c1 changed admin/articles.rb:407 to use a symbol
+    # instead of a string as the hash's key. The gem OJ then creates a json
+    # key like ":mykey" instead of the expected "mykey". If we use a
+    # string for the hash's key this does not occur.
+    #
+    # This could also be solved by using the :compat mode of Oj. This mode
+    # is slower than the :object mode that is the default, though:
+    # Comparison:
+    #   classic:   446504.4 i/s
+    #   compat:   310683.9 i/s - 1.44x  slower
+    # That's why we should stick with the strings as hash keys, even though
+    # they might not suit the style guide definitions, and disable the check here.
+    # Details: https://github.com/ikuseiGmbH/Goldencobra/pull/83
+    #
+    # rubocop:disable Style/HashSyntax
     render json: Oj.dump("articles" => articles)
+    # rubocop:enable Style/HashSyntax
   end
 
   controller do

--- a/admin/articles.rb
+++ b/admin/articles.rb
@@ -404,7 +404,7 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
         )
       end
     end
-    render json: Oj.dump(articles: articles)
+    render json: Oj.dump("articles" => articles)
   end
 
   controller do

--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -114,7 +114,24 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
           .roots.as_json(only: [:id, :target, :title], methods: [:has_children])
       end
     end
-    render json: Oj.dump({"menues" => menus})
+
+    # The commit fcc35c1 changed admin/articles.rb:407 to use a symbol
+    # instead of a string as the hash's key. The gem OJ then creates a json
+    # key like ":mykey" instead of the expected "mykey". If we use a
+    # string for the hash's key this does not occur.
+    #
+    # This could also be solved by using the :compat mode of Oj. This mode
+    # is slower than the :object mode that is the default, though:
+    # Comparison:
+    #   classic:   446504.4 i/s
+    #   compat:   310683.9 i/s - 1.44x  slower
+    # That's why we should stick with the strings as hash keys, even though
+    # they might not suit the style guide definitions, and disable the check here.
+    # Details: https://github.com/ikuseiGmbH/Goldencobra/pull/83
+    #
+    # rubocop:disable Style/HashSyntax
+    render json: Oj.dump("menues" => menus)
+    # rubocop:enable Style/HashSyntax
   end
 
   #batch_action :destroy, false


### PR DESCRIPTION
The commit fcc35c12 changed `admin/articles.rb:407` to use a symbol
instead of a string as the hash's key. The gem OJ then creates a json
key like `":mykey"` instead of the expected `"mykey"`. If we use a
string for the hash's key this does not occur.

This could also be solved by using the `:compat` mode of Oj. This mode
is slower than the `:object` mode that is the default, though:

``` ruby
articles =
Goldencobra::Article.order(:url_name).roots.as_json(
  only: [:id, :url_path, :title, :url_name],
  methods: [:has_children, :restricted]
)
=> [{"id"=>2, "title"=>"401", "url_name"=>"401", "url_path"=>"/401",
"has_children"=>false, "restricted"=>false}, {"id"=>1, "title"=>"404",
"url_name"=>"404", "url_path"=>"/404", "has_children"=>false,
"restricted"=>false}, {"id"=>3, "title"=>"Willkommen",
"url_name"=>"willkommen", "url_path"=>"/", "has_children"=>false,
"restricted"=>false}]

Benchmark.ips do |x|
  x.report("compat") do
    Oj.dump({articles: articles}, mode: :compat)
  end
  x.report("classic") do
    Oj.dump("articles" => articles)
  end
  x.compare!
end
Warming up --------------------------------------
              compat    25.551k i/100ms
             classic    36.153k i/100ms
Calculating -------------------------------------
              compat    310.684k (±18.0%) i/s -      1.533M in
5.168329s
             classic    446.504k (± 8.4%) i/s -      2.241M in
5.057620s

Comparison:
             classic:   446504.4 i/s
              compat:   310683.9 i/s - 1.44x  slower
```

That's why we should stick with the strings as hash keys, even though
they might not suit the style guide definitions.