### PR TITLE
Settings cleanup

### DIFF
--- a/app/services/goldencobra/settings_cleanup.rb
+++ b/app/services/goldencobra/settings_cleanup.rb
@@ -44,7 +44,8 @@ module Goldencobra
             rescue Ancestry::AncestryException
               # If a `Ancestry::AncestryException` is thrown, than do not quit the
               # process because there could be some more settings to check in the loop.
-              # Go on with the next iteration step.
+              # Return true and go on with the next iteration step.
+              true
             end
           end
         end
@@ -52,7 +53,7 @@ module Goldencobra
       p "*" * 100
     end
 
-    # Searches for usages of settings in an Golden Cobra app source code.
+    # Searches for usages of settings in a Golden Cobra app source code.
     #
     # (!) only complete formats like "root.key1.key2.key3" will be recognized
     #
@@ -82,9 +83,11 @@ module Goldencobra
       Goldencobra::Setting.roots.where(title: settings_root).first.descendants.each do |setting|
         complete_setting = setting.path.pluck(:title).join(".")
         p "*" * 100
-        p complete_setting
+        p "Searching for #{complete_setting} in #{search_path}"
         p "-" * 100
-        system "grep -Rl '#{complete_setting}' #{search_path}"
+        unless system "grep -Rl '#{complete_setting}' #{search_path}"
+          p "#{complete_setting} not found in #{search_path}"
+        end
         p "*" * 100
       end
     end

--- a/app/services/goldencobra/settings_cleanup.rb
+++ b/app/services/goldencobra/settings_cleanup.rb
@@ -1,0 +1,92 @@
+module Goldencobra
+  # This class offers methods for helping to clean up Golden Cobra settings. They
+  # can be used all over the project and in some included gems. Some of them are
+  # not used anymore but still appear in the backend to edit. This produces overhead
+  # because they suggest to be important and one will fill them.
+  # If we remove the unused settings, nobody needs to care about them.
+  class SettingsCleanup
+    # Checks every single Goldencobra::Setting for presence or if it is still used.
+    #
+    # @param settings_path [string] the path of the settings.yml
+    #        Examples: Goldencobra::Engine.root + "config/settings.yml"
+    #                  GoldencobraEvents::Engine.root + "config/settings.yml"
+    def self.remove_unused_setting_keys(settings_path)
+      raise "Settings file '#{path_file_name}' does not exist" unless File.exist?(settings_path)
+
+      settings = open(settings_path) { |f| YAML.safe_load(f) }
+      settings_root = settings.each_key.first if settings.present?
+
+      return if settings_root.blank?
+
+      p "*" * 100
+      Goldencobra::Setting.roots.where(title: settings_root).first.descendants.each do |setting|
+        settings_to_fetch = settings
+        setting.path.pluck(:title).each do |key|
+          p "Setting key: #{key} - Setting path: #{setting.path.pluck(:title).join(".")}"
+          begin
+            # Traverse the setting path hierarchically from the outside into the deep.
+            #
+            # Example:
+            #   setting path = goldencobra.locations.geocoding
+            #
+            #   1. settings_to_fetch = {"goldencobra"=>{"locations"=>{"geocoding"=>"true"}}}
+            #   2. settings_to_fetch = {"locations"=>{"geocoding"=>"true"}}
+            #   3. settings_to_fetch = {"geocoding"=>"true"}
+            settings_to_fetch = settings_to_fetch.fetch(key)
+          rescue KeyError
+            begin
+              # If a 'KeyError' is thrown, the key is not present and the setting can be
+              # removed from the database.
+              p "Not present!"
+              p "Destroy setting: #{setting.title}"
+              p "-" * 100
+              setting.destroy
+            rescue Ancestry::AncestryException
+              # If a `Ancestry::AncestryException` is thrown, than do not quit the
+              # process because there could be some more settings to check in the loop.
+              # Go on with the next iteration step.
+            end
+          end
+        end
+      end
+      p "*" * 100
+    end
+
+    # Searches for usages of settings in an Golden Cobra app source code.
+    #
+    # (!) only complete formats like "root.key1.key2.key3" will be recognized
+    #
+    # The log output in the console is formatted a bit for better readability.
+    # The results has to be checked manually. Reported non-usages in one app
+    # needs to be checked in other included golden cobra engines (gems).
+    #
+    # Example:
+    #   "foo.bar" is not used in Goldencobra::Engine
+    #
+    #   1. check for usages in the app itself
+    #   2. check for usages in golden cobra events, if the gem is included
+    #
+    # @param settings_path [string] the path of the settings.yml
+    #        Examples: Goldencobra::Engine.root + "config/settings.yml"
+    #                  GoldencobraEvents::Engine.root + "config/settings.yml"
+    # @param search_path [string] the root path of the app to search in
+    #        Example: "../goldencobra-events"
+    def self.search_in_files(settings_path, search_path)
+      raise "Settings file '#{path_file_name}' does not exist" unless File.exist?(settings_path)
+
+      settings = open(settings_path) { |f| YAML.safe_load(f) }
+      settings_root = settings.each_key.first
+
+      return if settings_root.blank?
+
+      Goldencobra::Setting.roots.where(title: settings_root).first.descendants.each do |setting|
+        complete_setting = setting.path.pluck(:title).join(".")
+        p "*" * 100
+        p complete_setting
+        p "-" * 100
+        system "grep -Rl '#{complete_setting}' #{search_path}"
+        p "*" * 100
+      end
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,8 +23,8 @@ goldencobra:
   html2pdf_uid: "c5c13af822"
   use_solr: "false"
   page:
-    default_title_tag: "Enter your name to appear in Title-Tag after a pipe, e.g. Goldencobra for: YourTitle | Goldencobra - You found me in Goldencobra Settings"
-    default_meta_description_tag: "Enter your default MetaDescription: You found me in Goldencobra Settings"
+    default_title_tag: ""
+    default_meta_description_tag: ""
   article:
     preview:
       roles: "Admin"
@@ -37,10 +37,10 @@ goldencobra:
     article_index:
       link_to_article: "weiterlesen"
   use_ssl: "false"
-  url: "Enter your website url, e.g. www.goldencobra.de - You found me in Goldencobra Settings"
+  url: ""
   facebook:
-    appid: "Enter your facebook app id, e.g. 123456"
-    opengraph_default_image: "Enter a default image path to your open-graph image if available, e.g. /assets/open-graph.png - You found me in Goldencobra Settings"
+    appid: ""
+    opengraph_default_image: ""
   geocode_ip_address: "false"
   remove_old_versions:
     active: "true"


### PR DESCRIPTION
**COMMIT INFOS**

**Add service for cleaning up unused settings**

Problem:

There are settings listed in the backend and nobody knows, if they
are used or not. A lot of settings were changed to locales and
others are not used completely.
So they do not need to be filled with values.

Solution:

Unused settings should be removed from the database.
Therefore methods are introduced to check the
database against a yml-file and to check the code
for presence of setting keys.
If a setting in the database cannot be found in
the yml-file, it is unused and can be removed.
If a setting is not used in the code, its key will
be logged to the console and can be removed
from the yml-file.

**Cleanup settings with removing unnecessary values**

You always have to clean the website settings from dummy values,
because otherwise they will be rendered on pages.
This commit remvoes unnecessary values from the settings yml-file.

**USAGE**

To call these helpers one needs to enter the rails console of a project. The database of the project needs to be initialized with all migrations. The project needs to be runnable so the settings exist in the project's database.