### PR TITLE
Change default setting for geocoding to false

### DIFF
--- a/app/services/goldencobra/settings_cleanup.rb
+++ b/app/services/goldencobra/settings_cleanup.rb
@@ -29,9 +29,9 @@ module Goldencobra
             # Example:
             #   setting path = goldencobra.locations.geocoding
             #
-            #   1. settings_to_fetch = {"goldencobra"=>{"locations"=>{"geocoding"=>"true"}}}
-            #   2. settings_to_fetch = {"locations"=>{"geocoding"=>"true"}}
-            #   3. settings_to_fetch = {"geocoding"=>"true"}
+            #   1. settings_to_fetch = {"goldencobra"=>{"locations"=>{"geocoding"=>"false"}}}
+            #   2. settings_to_fetch = {"locations"=>{"geocoding"=>"false"}}
+            #   3. settings_to_fetch = {"geocoding"=>"false"}
             settings_to_fetch = settings_to_fetch.fetch(key)
           rescue KeyError
             begin

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,6 @@
 goldencobra:
   locations:
-    geocoding: "true"
+    geocoding: "false"
   live-support:
     active: "false"
     email: "metz@ikusei.de"

--- a/test/dummy/config/settings.yml
+++ b/test/dummy/config/settings.yml
@@ -1,3 +1,3 @@
 goldencobra:
   locations:
-    geocoding: "true"
+    geocoding: "false"

--- a/test/dummy/spec/initializers/settings_spec.rb
+++ b/test/dummy/spec/initializers/settings_spec.rb
@@ -2,6 +2,6 @@ require "spec_helper"
 
 describe "Settings initializer", type: :model do
   it "imports the default settings" do
-    expect(Goldencobra::Setting.for_key("goldencobra.locations.geocoding")).to eq "true"
+    expect(Goldencobra::Setting.for_key("goldencobra.locations.geocoding")).to eq "false"
   end
 end


### PR DESCRIPTION
There is a google quota which is reached fastly without api key. We are using geocoding without api key.

Usage limits:
https://developers.google.com/maps/faq?hl=de#usage-limits

In most cases the apps do not need geocoding, so this commits changes the default value of the geocoding setting from true to false.

For new apps it is important to think about geocoding from now on. If it is needed, the setting needs to be changed to true.

GC-163