### PR TITLE
Remove JavaScript for old widget timing feature

### DIFF
--- a/app/assets/javascripts/goldencobra/active_admin.js
+++ b/app/assets/javascripts/goldencobra/active_admin.js
@@ -213,32 +213,6 @@ $(function () {
 	// return false;
   // });
 
-  /**** DOM Manipulation Zeitsteuerung ****/
-  /* text input felder für den jeweiligen
-     tag in dom gruppieren */
-
-  // hilfsarray tage englisch kurz
-  var engDaysShort = ['mo', 'tu', 'we', 'th', 'fr', 'sa', 'su'];
-  // tages checkboxen elemente (mo, di, ..., so)
-  var checkBoxesDays = $('.choice');
-  // für jede checkbox die dazugehörigen input felder holen und anhängen
-  checkBoxesDays.each(function(i, el) {
-    // checkbox muss neue css styles erhalten
-    var addCssBox = {'float': 'left', 'width': '50px', 'margin-top': '8px'};
-    $(el).height(50).find('label').css(addCssBox);
-    // selektoren für start und end inputs eines tages
-    var startInput = $('#widget_offline_time_start_' + engDaysShort[i] + '_input');
-    var endInput = $('#widget_offline_time_end_' + engDaysShort[i] + '_input');
-    // label der inputs entfernen und benötigten css style ergänzen
-    var addCssInput = {'float': 'left', 'width': '180px'};
-    $(startInput).css(addCssInput).find('label').remove();
-    $(endInput).css(addCssInput).find('label').remove();
-    // inputs zur checkbox gruppieren
-    $(startInput).appendTo(el);
-    $(endInput).appendTo(el);
-  });
-  /**** END DOM Manipulation *****/
-
   $('ul.link_checker_ul div.link_checker_label').click(function() {
     $(this).siblings('.link_checker_sources').toggle();
   });

--- a/doc/versionhistory
+++ b/doc/versionhistory
@@ -1,3 +1,5 @@
+V2.0.5.2 - 27.06.2017
+  - Remove JavaScript for old widget timing feature
 V2.0.5.1 - 21.06.2017
   - Prevent errors on /admin/uploads if some uploads weren't saved properly
 V2.0.5 - 13.06.2017

--- a/lib/goldencobra/version.rb
+++ b/lib/goldencobra/version.rb
@@ -1,3 +1,3 @@
 module Goldencobra
-  VERSION = "2.0.5.1"
+  VERSION = "2.0.5.2"
 end


### PR DESCRIPTION
The JavaScript remaining after removing
the widgets timing feature caused bad radio button
styling in the backend.

This commit removes the unnecessary JavaScript.

Before:
<img width="1750" alt="bildschirmfoto 2017-06-19 um 19 37 16" src="https://user-images.githubusercontent.com/1942953/27583771-d0e0bbbe-5b35-11e7-974f-c0e0f8f8dfea.png">

After:
![bildschirmfoto 2017-06-27 um 12 41 36](https://user-images.githubusercontent.com/1942953/27583812-fb1c45ec-5b35-11e7-9670-1c6752e50962.png)
