### PR TITLE
Bugfix/set page online offline article check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "eventmachine", "~> 1.0.9.1"
 gem "pdfkit"
 gem "wkhtmltopdf-binary"
 
+# fix this version to 3.x to avoid method missing errors with version >= 4.0.0
 gem "liquid", "~> 3.0"
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem "eventmachine", "~> 1.0.9.1"
 gem "pdfkit"
 gem "wkhtmltopdf-binary"
 
+gem "liquid", "~> 3.0"
+
 group :development, :test do
   gem "debugger"
   gem "rspec-rails" # rspec in dev so the rake tasks run properly

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GIT
 PATH
   remote: .
   specs:
-    goldencobra (1.4.77.5)
+    goldencobra (1.4.8)
       active_model_serializers
       activeadmin
       activeadmin-cancan
@@ -73,7 +73,7 @@ PATH
       i18n-active_record
       iconv
       inherited_resources
-      jquery-rails (= 2.1.4)
+      jquery-rails (>= 2.1.4, < 4.0)
       liquid
       meta-tags
       multi_json
@@ -122,8 +122,9 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    active_model_serializers (0.9.5)
+    active_model_serializers (0.9.7)
       activemodel (>= 3.2)
+      concurrent-ruby (~> 1.0)
     activeadmin-cancan (0.1.4)
       activeadmin (>= 0.4.0)
       cancan (>= 1.6.2)
@@ -143,8 +144,8 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.8)
-    ancestry (2.1.0)
-      activerecord (>= 3.0.0)
+    ancestry (3.0.0)
+      activerecord (>= 3.2.0)
     annotate (2.6.10)
       activerecord (>= 3.2, <= 4.3)
       rake (~> 10.4)
@@ -229,6 +230,7 @@ GEM
       compass (>= 0.10.0)
     compass-rails (2.0.0)
       compass (>= 0.12.2)
+    concurrent-ruby (1.0.5)
     connection_pool (2.2.0)
     cucumber (2.0.2)
       builder (>= 2.1.2)
@@ -281,7 +283,7 @@ GEM
     friendly_id (4.0.10.1)
       activerecord (>= 3.0, < 4.0)
     fssm (0.2.10)
-    geocoder (1.3.4)
+    geocoder (1.4.4)
     geokit (1.7.1)
       multi_json (>= 1.3.2)
     gherkin (2.12.2)
@@ -390,7 +392,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
-    oj (2.15.0)
+    oj (3.2.1)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
@@ -419,7 +421,7 @@ GEM
     pr_geohash (1.0.0)
     pre-commit (0.26.0)
       pluginator (~> 1.1)
-    progress_bar (1.0.5)
+    progress_bar (1.1.0)
       highline (~> 1.6)
       options (~> 2.3.0)
     pry (0.10.3)
@@ -463,12 +465,11 @@ GEM
       ffi (>= 0.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    react-rails (1.6.2)
+    react-rails (1.11.0)
       babel-transpiler (>= 0.7.0)
-      coffee-script-source (~> 1.8)
       connection_pool
       execjs
-      rails (>= 3.2)
+      railties (>= 3.2)
       tilt
     redcarpet (3.3.3)
     redis (3.3.0)
@@ -572,9 +573,9 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket (1.2.2)
-    whenever (0.9.4)
+    whenever (0.9.7)
       chronic (>= 0.6.3)
-    wicked_pdf (1.0.6)
+    wicked_pdf (1.1.0)
     wkhtmltopdf-binary (0.9.9.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -622,6 +623,7 @@ DEPENDENCIES
   i18n-active_record!
   jquery-rails
   launchy
+  liquid (~> 3.0)
   listen
   memcache-client
   meta-tags!
@@ -661,4 +663,4 @@ DEPENDENCIES
   yarjuf
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/admin/articles.rb
+++ b/admin/articles.rb
@@ -116,7 +116,7 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
       article.public_url
     end
     column I18n.t('active_admin.articles.index.active'), :active, sortable: :active do |article|
-      link_to(article.active ? "online" : "offline", set_page_online_offline_admin_article_path(article), title: "#{article.active ? 'Artikel offline stellen' : 'Artikel online stellen'}", confirm: I18n.t("online", scope: [:goldencobra, :flash_notice]), class: "member_link edit_link #{article.active ? 'online' : 'offline'}")
+      link_to(article.active ? "online" : "offline", set_page_online_offline_admin_article_path(article.id), title: "#{article.active ? 'Artikel offline stellen' : 'Artikel online stellen'}", confirm: I18n.t("online", scope: [:goldencobra, :flash_notice]), class: "member_link edit_link #{article.active ? 'online' : 'offline'}")
     end
     column I18n.t('active_admin.articles.index.article_type'), :article_type, sortable: :article_type do |article|
       article.article_type.blank? ? I18n.t('active_admin.articles.index.default') : I18n.t(article.article_type.parameterize.underscore.downcase, scope: [:goldencobra, :article_types])
@@ -249,14 +249,19 @@ ActiveAdmin.register Goldencobra::Article, as: "Article" do
 
   member_action :set_page_online_offline do
     article = Goldencobra::Article.find_by_id(params[:id])
-    if article.active
-      article.active = false
-      flash[:notice] = I18n.t('active_admin.articles.member_action.flash.article_offline')
+
+    if article
+      if article.active
+        article.active = false
+        flash[:notice] = I18n.t('active_admin.articles.member_action.flash.article_offline')
+      else
+        article.active = true
+        flash[:notice] = I18n.t('active_admin.articles.member_action.flash.article_online')
+      end
+      article.save
     else
-      article.active = true
-      flash[:notice] = I18n.t('active_admin.articles.member_action.flash.article_online')
+      flash[:notice] = I18n.t('active_admin.articles.member_action.flash.article_not_edited')
     end
-    article.save
 
     redirect_to action: :index
   end

--- a/config/locales/active_admin.de.yml
+++ b/config/locales/active_admin.de.yml
@@ -294,6 +294,7 @@ de:
         flash:
           article_online: "Dieser Artikel ist nun online"
           article_offline: "Dieser Artikel ist nun offline"
+          article_not_edited: "Artikel konnte nicht gefunden und verarbeitet werden."
           widgets: "Widgets added"
           link_checker: "Die Links dieses Artikels werden überprüft. Bitte warten Sie, dies kann wenige Minuten in Anspruch nehmen."
       batch_action:

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -294,6 +294,7 @@ en:
         flash:
           article_online: "This article is now online."
           article_offline: "This article is now offline."
+          article_not_edited: "Article not found and not edited."
           widgets: "Widgets added"
           link_checker: "Links for this article will be inspected. This can take couple of minutes. Thank you for your patience."
       batch_action:


### PR DESCRIPTION
There was a bug in the release/1.5 version with the member action setting articles online or offline.

This PR is for fixing and optimizing this part.

The slug of an article was used wrongly instead of the id of an article to find it. If an article was not found, there was no catching case.
We need a correct use of id to identify an article. The slug is not unique in any case. This is fixed now.

If an article was not found per member action for setting it online or offline a 500 error was thrown.
Now this is also fixed now with an check of article and an else case with showing a new flash message that the article was not found and not edited.