### PR TITLE
Css class with dashes

### DIFF
--- a/app/helpers/goldencobra/navigation_helper.rb
+++ b/app/helpers/goldencobra/navigation_helper.rb
@@ -87,9 +87,9 @@ module Goldencobra
         end
 
         if id_name.present?
-          result = content_tag(:ul, raw(content),id: "#{id_name}", class: "#{class_name} #{depth} navigation #{master_menue.css_class.to_s.gsub(/\W/,' ')}".squeeze(' ').strip)
+          result = content_tag(:ul, raw(content),id: "#{id_name}", class: "#{class_name} #{depth} navigation #{master_menue.css_class.to_s.gsub(/[^A-z\-]/,' ')}".squeeze(' ').strip)
         else
-          result = content_tag(:ul, raw(content), class: "#{class_name} #{depth} navigation #{master_menue.css_class.to_s.gsub(/\W/,' ')}".squeeze(' ').strip)
+          result = content_tag(:ul, raw(content), class: "#{class_name} #{depth} navigation #{master_menue.css_class.to_s.gsub(/[^A-z\-]/,' ')}".squeeze(' ').strip)
         end
       end
       return raw(result)

--- a/app/helpers/goldencobra/navigation_helper.rb
+++ b/app/helpers/goldencobra/navigation_helper.rb
@@ -26,6 +26,7 @@ module Goldencobra
     #<%= navigation_menu("Top-Menu", current_article: @article, class: "ul_main_nav", depth: 1, offset: 1 %>
 
     # TODO: offset implementieren
+    # TODO: refactor method to make it easier to test
     def navigation_menu(menue_id, options={})
       return "id can't be blank" if menue_id.blank?
       depth = options[:depth] || 9999

--- a/test/dummy/spec/helpers/goldencobra/navigation_helper_spec.rb
+++ b/test/dummy/spec/helpers/goldencobra/navigation_helper_spec.rb
@@ -1,8 +1,9 @@
 require "spec_helper"
 
 describe Goldencobra::NavigationHelper, type: :helper do
-  it "gsub works correctly" do
-    expect("my-awesome-class").to_s.gsub(/[^A-z\-]/,' ').to eq("my-awesome-class")
-    expect("another_awesome_class").to_s.gsub(/[^A-z\-]/,' ').to eq("another_awesome_class")
+  it "uses gsub correctly" do
+    expect(("my-awesome-class").to_s.gsub(/[^A-z\-]/,' ')).to eq("my-awesome-class")
+    expect(("another_awesome_class").to_s.gsub(/[^A-z\-]/,' ')).to eq("another_awesome_class")
+    expect(("not A%N awes$me_*+wCl!ass --but-dashes-work").to_s.gsub(/[^A-z\-]/,' ')).to eq("not A N awes me_  wCl ass --but-dashes-work")
   end
 end

--- a/test/dummy/spec/helpers/goldencobra/navigation_helper_spec.rb
+++ b/test/dummy/spec/helpers/goldencobra/navigation_helper_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+
+describe Goldencobra::NavigationHelper, type: :helper do
+  it "gsub works correctly" do
+    expect("my-awesome-class").to_s.gsub(/[^A-z\-]/,' ').to eq("my-awesome-class")
+    expect("another_awesome_class").to_s.gsub(/[^A-z\-]/,' ').to eq("another_awesome_class")
+  end
+end


### PR DESCRIPTION
NavigationHelper is now also able to render css classes with dashes. Previously each word of a class with dashes was seen as a class itself, f.e. "my-awesome-class" was rendered as three classes: my awesome class

[Note: I am happy to receive feedback on how to test css classes, right now I just made sure that the gsub works correctly, since a dash "-" is considered as a "non-word-character" and that's why it was 'gsubbed' before]

#69