### PR TITLE
Show column for parent element

### DIFF
--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -65,7 +65,7 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
       end
     end
     column I18n.t("active_admin.menues.form.index.column6") do |menue|
-      if menue.parent_id.present?
+      if menue.parent_id.present? && Goldencobra::Menue.exists?(menue.parent_id)
         Goldencobra::Menue.find(menue.parent_id).title
       end
     end

--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -64,6 +64,11 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
         link_to(I18n.t("active_admin.menues.form.index.search_link1"), new_admin_article_path(article: {title: menue.title, url_name: menue.target.to_s.split('/').last}), class: "create", title: I18n.t("active_admin.menues.form.index.search_title1"))
       end
     end
+    column I18n.t("active_admin.menues.form.index.column6") do |menue|
+      unless menue.parent_id.nil?
+        Goldencobra::Menue.find(menue.parent_id).title
+      end
+    end
     column "" do |menue|
       result = ""
       result += link_to(I18n.t("active_admin.menues.form.column.edit"), edit_admin_menue_path(menue), class: "member_link edit_link edit", title: I18n.t("active_admin.menues.form.column.edit_title"))

--- a/admin/menues.rb
+++ b/admin/menues.rb
@@ -65,7 +65,7 @@ ActiveAdmin.register Goldencobra::Menue, as: "Menue" do
       end
     end
     column I18n.t("active_admin.menues.form.index.column6") do |menue|
-      unless menue.parent_id.nil?
+      if menue.parent_id.present?
         Goldencobra::Menue.find(menue.parent_id).title
       end
     end

--- a/config/locales/active_admin.de.yml
+++ b/config/locales/active_admin.de.yml
@@ -413,6 +413,7 @@ de:
           column3: "Sortieren"
           column4: "Zugriff"
           column5: "Artikel"
+          column6: "Elternelement"
           search_link: "search"
           search_class: "list"
           search_title: "Artikel auflisten"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -413,6 +413,7 @@ en:
           column3: "Sort"
           column4: "Access"
           column5: "Article"
+          column6: "Parent element"
           search_link: "search"
           search_class: "list"
           search_title: "List article"


### PR DESCRIPTION
The title of the parent element for each menue entry - if one exists - is now shown in the menue index view. Translations for this column were added as well.

#63 