### PR TITLE
copied widgets keep their positions

### DIFF
--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -46,8 +46,7 @@
 #  author_id                        :integer
 #
 
-
-#For article rendering to string (:render_html) needed
+# For article rendering to string (:render_html) needed
 include Goldencobra::ApplicationHelper
 require "open-uri"
 
@@ -55,7 +54,7 @@ module Goldencobra
   class Article < ActiveRecord::Base
     include Goldencobra::ArticleConcerns::MetaTag
 
-    #extend FriendlyId
+    # extend FriendlyId
     LiquidParser = {}
     SortOptions = ["Created_at", "Updated_at", "Random", "Alphabetically", "GlobalSortID"]
     DynamicRedirectOptions = [[:false,"deaktiviert"],[:latest,"neuester Untereintrag"], [:oldest, "ältester Untereintrag"]]
@@ -417,7 +416,7 @@ module Goldencobra
 
     # scope for index articles, display show-articles, index-articles or both articletypes
     def self.articletype_for_index(current_article)
-      #Wenn alle Artikeltypen angezeigt werden sollen
+      # Wenn alle Artikeltypen angezeigt werden sollen
       if current_article.display_index_articletypes == "all"
         if current_article.display_index_types == "show"
           where("article_type LIKE '% Show' ")
@@ -427,7 +426,7 @@ module Goldencobra
           where("article_type LIKE '% Show' OR article_type LIKE '% Index' ")
         end
       else
-        #Wenn NUR Artikel von EINEM bestimmten Artkeltypen angezeigt werden sollen
+        # Wenn NUR Artikel von EINEM bestimmten Artkeltypen angezeigt werden sollen
         if current_article.display_index_types == "show"
           articletype("#{current_article.display_index_articletypes} Show")
         elsif current_article.display_index_types == "index"

--- a/app/models/goldencobra/widget.rb
+++ b/app/models/goldencobra/widget.rb
@@ -188,7 +188,7 @@ module Goldencobra
       attrs["title"] = "#{attrs["title"]} (Kopie)"
       attrs["id_name"] = attrs["id_name"].present? ? "#{attrs["id_name"]}-kopie" : nil
       attrs["active"] = false
-      attrs["tag_list"] = self.tag_list
+      attrs["tag_list"] = tag_list
       new_widget = Goldencobra::Widget.create!(attrs)
       new_widget ? new_widget.id : nil
     end

--- a/app/models/goldencobra/widget.rb
+++ b/app/models/goldencobra/widget.rb
@@ -188,6 +188,7 @@ module Goldencobra
       attrs["title"] = "#{attrs["title"]} (Kopie)"
       attrs["id_name"] = attrs["id_name"].present? ? "#{attrs["id_name"]}-kopie" : nil
       attrs["active"] = false
+      attrs["tag_list"] = self.tag_list
       new_widget = Goldencobra::Widget.create!(attrs)
       new_widget ? new_widget.id : nil
     end

--- a/test/dummy/spec/models/widget_spec.rb
+++ b/test/dummy/spec/models/widget_spec.rb
@@ -26,6 +26,8 @@ describe Goldencobra::Widget do
         teaser: "Teaser Content"
       )
 
+      @widget_one.tag_list = "left, sidebar"
+
       duplicated_widget_id = @widget_one.duplicate!
       dup_widget = Goldencobra::Widget.find(duplicated_widget_id)
       dup_attrs = dup_widget.attributes.delete_if{ |a| %w(created_at updated_at).include?(a) }
@@ -33,6 +35,7 @@ describe Goldencobra::Widget do
       expect(duplicated_widget_id).to eq(Goldencobra::Widget.last.id)
       expect(Goldencobra::Widget.count).to eq(2)
       expect(dup_attrs).to eq(dupl_attributes.merge!({ "id" => duplicated_widget_id}))
+      expect(@widget_one.tag_list).to eq(dup_widget.tag_list)
     end
   end
 


### PR DESCRIPTION
The tag_list for each widget is copied when the widget is copied. Previously it was set to "sidebar" by default. If the tag_list is empty in the original widget, the copied widget still gets the position "sidebar".
(also small codeclimate linting issues were fixed -> missing spaces)

#99 