### PR TITLE
Rescue OverQueryLimitErrors when commiting records

### DIFF
--- a/app/models/goldencobra/location.rb
+++ b/app/models/goldencobra/location.rb
@@ -29,8 +29,12 @@ module Goldencobra
     attr_accessor :skip_geocode
 
     geocoded_by :complete_location, latitude: :lat, longitude: :lng
-    after_validation :geocode, unless: :skip_geocoding_once_or_always
+    after_validation :safe_geocode, unless: :skip_geocoding_once_or_always
 
+    def safe_geocode
+      geocode
+    rescue Geocoder::OverQueryLimitError
+    end
 
     liquid_methods :street, :city, :zip, :region, :country, :title
     belongs_to :locateable, polymorphic: true

--- a/test/dummy/spec/models/location_spec.rb
+++ b/test/dummy/spec/models/location_spec.rb
@@ -22,6 +22,38 @@ describe Goldencobra::Location do
     )
   end
 
+  describe "safe_geocoding" do
+    before do
+      expect_any_instance_of(Goldencobra::Location)
+        .to receive(:do_lookup).and_raise(Geocoder::OverQueryLimitError)
+    end
+
+    it "ignores the error and creates the record" do
+      expect {
+        Goldencobra::Location.create(
+          street: "Zossener Str. 55",
+          city: "Berlin",
+          zip: "10961"
+        )
+      }.to change(Goldencobra::Location, :count).from(0).to(1)
+    end
+
+    it "saves the given attributes" do
+        Goldencobra::Location.create(
+          street: "Zossener Str. 55",
+          city: "Berlin",
+          zip: "10961"
+        )
+
+      expect(
+        Goldencobra::Location.where(
+          street: "Zossener Str. 55",
+          city: "Berlin",
+          zip: "10961"
+        ).exists?).to eq(true)
+    end
+  end
+
   context "with a valid address" do
     it "should have a latitude and longitude" do
       location = Goldencobra::Location.create(street: "Zossener Str. 55",


### PR DESCRIPTION
The `geocode` call was configured to always raise the
`Geocoder::OverQueryLimitError` error. I think this is the right
decision, but I still want the changes to the records to be saved.

Fixes issue #98