### PR TITLE
Rescue OverQueryLimitErrors when commiting records

### DIFF
--- a/test/dummy/spec/models/location_spec.rb
+++ b/test/dummy/spec/models/location_spec.rb
@@ -5,14 +5,18 @@ require 'spec_helper'
 describe Goldencobra::Location do
 
   it "should have a latitude and longitude" do
-    location = Goldencobra::Location.create(:street => "Zossener Str. 55", :city => "Berlin", :zip => "10961")
+    location = Goldencobra::Location.create(
+      :street => "Zossener Str. 55", :city => "Berlin", :zip => "10961"
+    )
     location.lat.should_not == nil
     location.lng.should_not == nil
     Goldencobra::Location.find_by_zip("10961").street.should == "Zossener Str. 55"
   end
 
   it "should have no latitude and longitude because of missing city" do
-    location = Goldencobra::Location.create(:street => "Puccinistrasse 40", :city => "", :zip => "13088")
+    location = Goldencobra::Location.create(
+      :street => "Puccinistrasse 40", :city => "", :zip => "13088"
+    )
     location.lat.should == nil
     location.lng.should == nil
     Goldencobra::Location.find_by_zip("13088").street.should == "Puccinistrasse 40"
@@ -24,5 +28,35 @@ describe Goldencobra::Location do
     location.lng.should == nil
   end
 
+  describe "safe_geocoding" do
+    before do
+      expect_any_instance_of(Goldencobra::Location)
+        .to receive(:do_lookup).and_raise(Geocoder::OverQueryLimitError)
+    end
 
+    it "ignores the error and creates the record" do
+      expect {
+        Goldencobra::Location.create(
+          street: "Zossener Str. 55",
+          city: "Berlin",
+          zip: "10961"
+        )
+      }.to change(Goldencobra::Location, :count).from(0).to(1)
+    end
+
+    it "saves the given attributes" do
+      Goldencobra::Location.create(
+        street: "Zossener Str. 55",
+        city: "Berlin",
+        zip: "10961"
+      )
+
+      expect(
+        Goldencobra::Location.where(
+          street: "Zossener Str. 55",
+          city: "Berlin",
+          zip: "10961"
+        ).exists?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
The `geocode` call was configured to always raise the
`Geocoder::OverQueryLimitError` error. I think this is the right
decision, but I still want the changes to the records to be saved.

Fixes issue #98