### PR TITLE
Feature/mm layouts for articletypes

### DIFF
--- a/admin/articletypes.rb
+++ b/admin/articletypes.rb
@@ -14,10 +14,12 @@ ActiveAdmin.register Goldencobra::Articletype, as: "Articletype" do
   end
 
   form html: { enctype: "multipart/form-data" }  do |f|
+    f.actions
     f.inputs I18n.t("active_admin.articletypes.general") do
       f.input :default_template_file, as: :select,
-              collection: Goldencobra::Article.templates_for_select, include_blank: false,
-              label: "Standardlayout"
+              collection: Goldencobra::Template.all.map { |t| [t.title, t.layout_file_name]}, include_blank: false,
+              label: label: I18n.t("active_admin.articletypes.default_template")
+      f.input :templates, as: :check_boxes, collection: Goldencobra::Template.all.map { |t| [t.title, t.id]}, label: I18n.t("active_admin.articletypes.templates")
     end
     f.inputs I18n.t("active_admin.articletypes.article_fields"), class: "foldable" do
       f.has_many :fieldgroups, heading: "", new_record: "+ Feldgruppe hinzufügen" do |fg|
@@ -49,6 +51,14 @@ ActiveAdmin.register Goldencobra::Articletype, as: "Articletype" do
       end
     end
     f.actions
+  end
+
+  controller do
+    def show
+      show! do |format|
+         format.html { redirect_to edit_admin_articletype_path(@articletype)}
+      end
+    end
   end
 
 end

--- a/admin/articletypes.rb
+++ b/admin/articletypes.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register Goldencobra::Articletype, as: "Articletype" do
     f.inputs I18n.t("active_admin.articletypes.general") do
       f.input :default_template_file, as: :select,
               collection: Goldencobra::Template.all.map { |t| [t.title, t.layout_file_name]}, include_blank: false,
-              label: label: I18n.t("active_admin.articletypes.default_template")
+              label: I18n.t("active_admin.articletypes.default_template")
       f.input :templates, as: :check_boxes, collection: Goldencobra::Template.all.map { |t| [t.title, t.id]}, label: I18n.t("active_admin.articletypes.templates")
     end
     f.inputs I18n.t("active_admin.articletypes.article_fields"), class: "foldable" do

--- a/admin/templates.rb
+++ b/admin/templates.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register Goldencobra::Template, as: "Template" do
+  menu parent: I18n.t("settings", scope: ["active_admin","menue"]),
+       label: I18n.t("active_admin.template.as"), if: proc{can?(:update, Goldencobra::Article)}
+end

--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -863,12 +863,6 @@ module Goldencobra
       return results
     end
 
-    def self.templates_for_select
-      Dir.glob(File.join(::Rails.root, "app", "views", "layouts", "*.html.erb"))
-         .map { |a| File.basename(a, ".html.erb") }
-         .delete_if { |a| a =~ /^_/ }
-    end
-
     def self.simple_search(q)
       active.search(title_or_subtitle_or_url_name_or_content_or_summary_or_teaser_contains: q).relation.map do |article|
         {

--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -3,47 +3,64 @@
 #
 # Table name: goldencobra_articles
 #
-#  id                               :integer          not null, primary key
-#  title                            :string(255)
-#  created_at                       :datetime         not null
-#  updated_at                       :datetime         not null
-#  url_name                         :string(255)
-#  slug                             :string(255)
-#  content                          :text
-#  teaser                           :text
-#  ancestry                         :string(255)
-#  startpage                        :boolean          default(FALSE)
-#  active                           :boolean          default(TRUE)
-#  subtitle                         :string(255)
-#  summary                          :text
-#  context_info                     :text
-#  canonical_url                    :string(255)
-#  robots_no_index                  :boolean          default(FALSE)
-#  breadcrumb                       :string(255)
-#  template_file                    :string(255)
-#  article_for_index_id             :integer
-#  article_for_index_levels         :integer          default(0)
-#  article_for_index_count          :integer          default(0)
-#  article_for_index_images         :boolean          default(FALSE)
-#  enable_social_sharing            :boolean
-#  cacheable                        :boolean          default(TRUE)
-#  image_gallery_tags               :string(255)
-#  article_type                     :string(255)
-#  external_url_redirect            :string(255)
-#  index_of_articles_tagged_with    :string(255)
-#  sort_order                       :string(255)
-#  reverse_sort                     :boolean
-#  author_backup                    :string(255)
-#  sorter_limit                     :integer
-#  not_tagged_with                  :string(255)
-#  use_frontend_tags                :boolean          default(FALSE)
-#  dynamic_redirection              :string(255)      default("false")
-#  redirection_target_in_new_window :boolean          default(FALSE)
-#  commentable                      :boolean          default(FALSE)
-#  active_since                     :datetime         default(2012-09-30 12:53:13 UTC)
-#  redirect_link_title              :string(255)
-#  display_index_types              :string(255)      default("show")
-#  author_id                        :integer
+#  id                                  :integer          not null, primary key
+#  title                               :string(255)
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#  url_name                            :string(255)
+#  slug                                :string(255)
+#  content                             :text(65535)
+#  teaser                              :text(65535)
+#  ancestry                            :string(255)
+#  startpage                           :boolean          default(FALSE)
+#  active                              :boolean          default(TRUE)
+#  subtitle                            :string(255)
+#  summary                             :text(65535)
+#  context_info                        :text(65535)
+#  canonical_url                       :string(255)
+#  robots_no_index                     :boolean          default(FALSE)
+#  breadcrumb                          :string(255)
+#  template_file                       :string(255)
+#  article_for_index_id                :integer
+#  article_for_index_levels            :integer          default(0)
+#  article_for_index_count             :integer          default(0)
+#  enable_social_sharing               :boolean
+#  article_for_index_images            :boolean          default(FALSE)
+#  cacheable                           :boolean          default(TRUE)
+#  image_gallery_tags                  :string(255)
+#  article_type                        :string(255)
+#  external_url_redirect               :string(255)
+#  index_of_articles_tagged_with       :string(255)
+#  sort_order                          :string(255)
+#  reverse_sort                        :boolean
+#  sorter_limit                        :integer
+#  not_tagged_with                     :string(255)
+#  use_frontend_tags                   :boolean          default(FALSE)
+#  dynamic_redirection                 :string(255)      default("false")
+#  redirection_target_in_new_window    :boolean          default(FALSE)
+#  commentable                         :boolean          default(FALSE)
+#  active_since                        :datetime         default(Fri, 03 Oct 2014 09:43:07 CEST +02:00)
+#  redirect_link_title                 :string(255)
+#  display_index_types                 :string(255)      default("all")
+#  creator_id                          :integer
+#  external_referee_id                 :string(255)
+#  external_referee_ip                 :string(255)
+#  external_updated_at                 :datetime
+#  image_gallery_type                  :string(255)      default("lightbox")
+#  url_path                            :text(65535)
+#  global_sorting_id                   :integer          default(0)
+#  display_index_articletypes          :string(255)      default("all")
+#  index_of_articles_descendents_depth :string(255)      default("1")
+#  ancestry_depth                      :integer          default(0)
+#  metatag_title_tag                   :string(255)
+#  metatag_meta_description            :string(255)
+#  metatag_open_graph_title            :string(255)
+#  metatag_open_graph_description      :string(255)
+#  metatag_open_graph_type             :string(255)      default("website")
+#  metatag_open_graph_url              :string(255)
+#  metatag_open_graph_image            :string(255)
+#  state                               :integer          default(0)
+#  display_index_articles              :boolean          default(FALSE)
 #
 
 # For article rendering to string (:render_html) needed

--- a/app/models/goldencobra/article_url.rb
+++ b/app/models/goldencobra/article_url.rb
@@ -52,3 +52,14 @@ module Goldencobra
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_article_urls
+#
+#  id         :integer          not null, primary key
+#  article_id :integer
+#  url        :text(65535)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/models/goldencobra/articletype.rb
+++ b/app/models/goldencobra/articletype.rb
@@ -115,3 +115,14 @@ module Goldencobra
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_articletypes
+#
+#  id                    :integer          not null, primary key
+#  name                  :string(255)
+#  default_template_file :string(255)
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#

--- a/app/models/goldencobra/articletype.rb
+++ b/app/models/goldencobra/articletype.rb
@@ -1,10 +1,11 @@
 module Goldencobra
   class Articletype < ActiveRecord::Base
-    attr_accessible :default_template_file, :name, :fieldgroups_attributes
+    attr_accessible :default_template_file, :name, :fieldgroups_attributes, :template_ids
 
     has_many :articles, class_name: Goldencobra::Article, foreign_key: :article_type, primary_key: :name
     has_many :fieldgroups, class_name: Goldencobra::ArticletypeGroup, dependent: :destroy
-
+    has_many :articletype_templates
+    has_many :templates, through: :articletype_templates
     accepts_nested_attributes_for :fieldgroups, allow_destroy: true
 
     validates_uniqueness_of :name

--- a/app/models/goldencobra/articletype_field.rb
+++ b/app/models/goldencobra/articletype_field.rb
@@ -10,3 +10,16 @@ module Goldencobra
     default_scope { order(:sorter) }
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_articletype_fields
+#
+#  id                   :integer          not null, primary key
+#  articletype_group_id :integer
+#  fieldname            :string(255)
+#  sorter               :integer          default(0)
+#  class_name           :string(255)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#

--- a/app/models/goldencobra/articletype_group.rb
+++ b/app/models/goldencobra/articletype_group.rb
@@ -11,3 +11,19 @@ module Goldencobra
     default_scope { order(:sorter) }
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_articletype_groups
+#
+#  id             :integer          not null, primary key
+#  title          :string(255)
+#  expert         :boolean          default(FALSE)
+#  foldable       :boolean          default(TRUE)
+#  closed         :boolean          default(TRUE)
+#  sorter         :integer          default(0)
+#  articletype_id :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  position       :string(255)      default("first_block")
+#

--- a/app/models/goldencobra/articletype_template.rb
+++ b/app/models/goldencobra/articletype_template.rb
@@ -1,0 +1,17 @@
+module Goldencobra
+  class ArticletypeTemplate < ActiveRecord::Base
+    belongs_to :template
+    belongs_to :articletype
+  end
+end
+
+# == Schema Information
+#
+# Table name: goldencobra_articletype_templates
+#
+#  id             :integer          not null, primary key
+#  articletype_id :integer
+#  template_id    :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#

--- a/app/models/goldencobra/author.rb
+++ b/app/models/goldencobra/author.rb
@@ -14,3 +14,16 @@ module Goldencobra
 		end
 	end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_authors
+#
+#  id         :integer          not null, primary key
+#  firstname  :string(255)
+#  lastname   :string(255)
+#  email      :string(255)
+#  googleplus :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/models/goldencobra/comment.rb
+++ b/app/models/goldencobra/comment.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_comments
@@ -8,7 +7,7 @@
 #  article_id       :integer
 #  commentator_id   :integer
 #  commentator_type :string(255)
-#  content          :text
+#  content          :text(65535)
 #  active           :boolean          default(TRUE)
 #  approved         :boolean          default(FALSE)
 #  reported         :boolean          default(FALSE)

--- a/app/models/goldencobra/domain.rb
+++ b/app/models/goldencobra/domain.rb
@@ -36,3 +36,17 @@ module Goldencobra
 
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_domains
+#
+#  id         :integer          not null, primary key
+#  hostname   :string(255)
+#  title      :string(255)
+#  client     :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  url_prefix :string(255)
+#  main       :boolean          default(FALSE)
+#

--- a/app/models/goldencobra/help.rb
+++ b/app/models/goldencobra/help.rb
@@ -1,12 +1,11 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_helps
 #
 #  id          :integer          not null, primary key
 #  title       :string(255)
-#  description :text
+#  description :text(65535)
 #  url         :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/models/goldencobra/import.rb
+++ b/app/models/goldencobra/import.rb
@@ -1,21 +1,20 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_imports
 #
 #  id                :integer          not null, primary key
-#  assignment        :text
-#  assignment_groups :text
+#  assignment        :text(65535)
 #  target_model      :string(255)
 #  successful        :boolean
 #  upload_id         :integer
 #  separator         :string(255)      default(",")
-#  result            :text
+#  result            :text(65535)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  encoding_type     :string(255)
+#  assignment_groups :text(65535)
 #
-
 
 # Dynamische Importfunktionen:
 # Jedes Model welches eigene Importfunktionen anbieten will muss lediglich eine liste der verfügbaren funktionen ImportDataFunctions = [] haben

--- a/app/models/goldencobra/import_metadata.rb
+++ b/app/models/goldencobra/import_metadata.rb
@@ -11,3 +11,20 @@ module Goldencobra
     belongs_to :importmetatagable, polymorphic: true
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_import_metadata
+#
+#  id                        :integer          not null, primary key
+#  database_owner            :string(255)
+#  exported_at               :datetime
+#  database_admin_first_name :string(255)
+#  database_admin_last_name  :string(255)
+#  database_admin_phone      :string(255)
+#  database_admin_email      :string(255)
+#  importmetatagable_id      :integer
+#  importmetatagable_type    :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#

--- a/app/models/goldencobra/link_checker.rb
+++ b/app/models/goldencobra/link_checker.rb
@@ -75,3 +75,18 @@ module Goldencobra
 
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_link_checkers
+#
+#  id             :integer          not null, primary key
+#  article_id     :integer
+#  target_link    :text(65535)
+#  position       :text(65535)
+#  response_code  :string(255)
+#  response_time  :string(255)
+#  response_error :text(65535)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#

--- a/app/models/goldencobra/location.rb
+++ b/app/models/goldencobra/location.rb
@@ -1,23 +1,23 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_locations
 #
-#  id              :integer          not null, primary key
-#  lat             :string(255)
-#  lng             :string(255)
-#  street          :string(255)
-#  city            :string(255)
-#  zip             :string(255)
-#  region          :string(255)
-#  country         :string(255)
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  title           :string(255)
-#  street_number   :string(255)
-#  locateable_type :string(255)
-#  locateable_id   :integer
+#  id               :integer          not null, primary key
+#  lat              :string(255)
+#  lng              :string(255)
+#  street           :string(255)
+#  city             :string(255)
+#  zip              :string(255)
+#  region           :string(255)
+#  country          :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  title            :string(255)
+#  locateable_type  :string(255)
+#  locateable_id    :integer
+#  street_number    :string(255)
+#  manual_geocoding :boolean          default(FALSE)
 #
 
 module Goldencobra

--- a/app/models/goldencobra/menue.rb
+++ b/app/models/goldencobra/menue.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_menues
@@ -13,10 +12,12 @@
 #  updated_at          :datetime         not null
 #  ancestry            :string(255)
 #  sorter              :integer          default(0)
-#  description         :text
+#  description         :text(65535)
 #  call_to_action_name :string(255)
 #  description_title   :string(255)
 #  image_id            :integer
+#  ancestry_depth      :integer          default(0)
+#  remote              :boolean          default(FALSE)
 #
 
 module Goldencobra

--- a/app/models/goldencobra/permission.rb
+++ b/app/models/goldencobra/permission.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_permissions
@@ -9,10 +8,11 @@
 #  subject_class :string(255)
 #  subject_id    :string(255)
 #  role_id       :integer
-#  domain_id     :integer
+#  sorter_id     :integer          default(0)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  sorter_id     :integer          default(0)
+#  operator_id   :integer
+#  domain_id     :integer
 #
 
 module Goldencobra

--- a/app/models/goldencobra/redirector.rb
+++ b/app/models/goldencobra/redirector.rb
@@ -129,3 +129,17 @@ module Goldencobra
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_redirectors
+#
+#  id                :integer          not null, primary key
+#  source_url        :text(65535)
+#  target_url        :text(65535)
+#  redirection_code  :integer          default(301)
+#  active            :boolean          default(TRUE)
+#  ignore_url_params :boolean          default(TRUE)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#

--- a/app/models/goldencobra/role.rb
+++ b/app/models/goldencobra/role.rb
@@ -1,12 +1,11 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_roles
 #
 #  id                   :integer          not null, primary key
 #  name                 :string(255)
-#  description          :text
+#  description          :text(65535)
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  redirect_after_login :string(255)      default("reload")

--- a/app/models/goldencobra/role_user.rb
+++ b/app/models/goldencobra/role_user.rb
@@ -1,13 +1,10 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_roles_users
 #
 #  operator_id   :integer
 #  role_id       :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
 #  operator_type :string(255)      default("User")
 #
 

--- a/app/models/goldencobra/template.rb
+++ b/app/models/goldencobra/template.rb
@@ -1,0 +1,25 @@
+module Goldencobra
+  class Template < ActiveRecord::Base
+    attr_accessible :title, :layout_file_name
+
+    # List all layout files found in folder /app/views/layouts
+    #
+    # @return [Array] List of file names
+    def self.layouts_for_select
+      Dir.glob(File.join(::Rails.root, "app", "views", "layouts", "*.html.erb"))
+         .map { |a| File.basename(a, ".html.erb") }
+         .delete_if { |a| a =~ /^_/ }
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: goldencobra_templates
+#
+#  id               :integer          not null, primary key
+#  title            :string(255)
+#  layout_file_name :string(255)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#

--- a/app/models/goldencobra/tracking.rb
+++ b/app/models/goldencobra/tracking.rb
@@ -1,11 +1,10 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_trackings
 #
 #  id             :integer          not null, primary key
-#  request        :text
+#  request        :text(65535)
 #  session_id     :string(255)
 #  referer        :string(255)
 #  url            :string(255)
@@ -18,7 +17,7 @@
 #  page_duration  :string(255)
 #  view_duration  :string(255)
 #  db_duration    :string(255)
-#  url_paremeters :string(255)
+#  url_paremeters :text(65535)
 #  utm_source     :string(255)
 #  utm_medium     :string(255)
 #  utm_term       :string(255)

--- a/app/models/goldencobra/upload.rb
+++ b/app/models/goldencobra/upload.rb
@@ -5,7 +5,7 @@
 #  id                 :integer          not null, primary key
 #  source             :string(255)
 #  rights             :string(255)
-#  description        :text
+#  description        :text(65535)
 #  image_file_name    :string(255)
 #  image_content_type :string(255)
 #  image_file_size    :integer
@@ -15,6 +15,7 @@
 #  attachable_type    :string(255)
 #  alt_text           :string(255)
 #  sorter_number      :integer
+#  image_remote_url   :string(255)
 #
 
 module Goldencobra

--- a/app/models/goldencobra/vita.rb
+++ b/app/models/goldencobra/vita.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_vita
@@ -9,10 +8,10 @@
 #  loggable_type :string(255)
 #  user_id       :integer
 #  title         :string(255)
-#  description   :text
+#  description   :text(65535)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  status_cd     :integer          default 0
+#  status_cd     :integer          default(0)
 #
 
 module Goldencobra

--- a/app/models/goldencobra/widget.rb
+++ b/app/models/goldencobra/widget.rb
@@ -1,30 +1,28 @@
 #encoding: utf-8
-
 # == Schema Information
 #
 # Table name: goldencobra_widgets
 #
 #  id                          :integer          not null, primary key
 #  title                       :string(255)
-#  content                     :text
+#  content                     :text(65535)
 #  css_name                    :string(255)
 #  active                      :boolean
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  id_name                     :string(255)
 #  sorter                      :integer
-#  mobile_content              :text
+#  mobile_content              :text(65535)
 #  teaser                      :string(255)
 #  default                     :boolean
-#  description                 :text
+#  description                 :text(65535)
 #  offline_days                :string(255)
 #  offline_time_active         :boolean
-#  alternative_content         :text
+#  alternative_content         :text(65535)
 #  offline_date_start          :date
 #  offline_date_end            :date
-#  offline_time_week_start_end :text
+#  offline_time_week_start_end :text(65535)
 #
-
 
 module Goldencobra
   class Widget < ActiveRecord::Base

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
-
 # == Schema Information
 #
 # Table name: translations
@@ -7,8 +6,8 @@
 #  id             :integer          not null, primary key
 #  locale         :string(255)
 #  key            :string(255)
-#  value          :text
-#  interpolations :text
+#  value          :text(65535)
+#  interpolations :text(65535)
 #  is_proc        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@
 #  linkedin               :string(255)
 #  xing                   :string(255)
 #  googleplus             :string(255)
-#  enable_expert_mode     :boolean          default(FALSE)
+#  enable_expert_mode     :boolean          default(TRUE)
 #
 
 class User < ActiveRecord::Base

--- a/app/serializers/goldencobra/article_serializer.rb
+++ b/app/serializers/goldencobra/article_serializer.rb
@@ -24,3 +24,67 @@ module Goldencobra
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_articles
+#
+#  id                                  :integer          not null, primary key
+#  title                               :string(255)
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#  url_name                            :string(255)
+#  slug                                :string(255)
+#  content                             :text(65535)
+#  teaser                              :text(65535)
+#  ancestry                            :string(255)
+#  startpage                           :boolean          default(FALSE)
+#  active                              :boolean          default(TRUE)
+#  subtitle                            :string(255)
+#  summary                             :text(65535)
+#  context_info                        :text(65535)
+#  canonical_url                       :string(255)
+#  robots_no_index                     :boolean          default(FALSE)
+#  breadcrumb                          :string(255)
+#  template_file                       :string(255)
+#  article_for_index_id                :integer
+#  article_for_index_levels            :integer          default(0)
+#  article_for_index_count             :integer          default(0)
+#  enable_social_sharing               :boolean
+#  article_for_index_images            :boolean          default(FALSE)
+#  cacheable                           :boolean          default(TRUE)
+#  image_gallery_tags                  :string(255)
+#  article_type                        :string(255)
+#  external_url_redirect               :string(255)
+#  index_of_articles_tagged_with       :string(255)
+#  sort_order                          :string(255)
+#  reverse_sort                        :boolean
+#  sorter_limit                        :integer
+#  not_tagged_with                     :string(255)
+#  use_frontend_tags                   :boolean          default(FALSE)
+#  dynamic_redirection                 :string(255)      default("false")
+#  redirection_target_in_new_window    :boolean          default(FALSE)
+#  commentable                         :boolean          default(FALSE)
+#  active_since                        :datetime         default(Fri, 03 Oct 2014 09:43:07 CEST +02:00)
+#  redirect_link_title                 :string(255)
+#  display_index_types                 :string(255)      default("all")
+#  creator_id                          :integer
+#  external_referee_id                 :string(255)
+#  external_referee_ip                 :string(255)
+#  external_updated_at                 :datetime
+#  image_gallery_type                  :string(255)      default("lightbox")
+#  url_path                            :text(65535)
+#  global_sorting_id                   :integer          default(0)
+#  display_index_articletypes          :string(255)      default("all")
+#  index_of_articles_descendents_depth :string(255)      default("1")
+#  ancestry_depth                      :integer          default(0)
+#  metatag_title_tag                   :string(255)
+#  metatag_meta_description            :string(255)
+#  metatag_open_graph_title            :string(255)
+#  metatag_open_graph_description      :string(255)
+#  metatag_open_graph_type             :string(255)      default("website")
+#  metatag_open_graph_url              :string(255)
+#  metatag_open_graph_image            :string(255)
+#  state                               :integer          default(0)
+#  display_index_articles              :boolean          default(FALSE)
+#

--- a/app/serializers/goldencobra/upload_serializer.rb
+++ b/app/serializers/goldencobra/upload_serializer.rb
@@ -20,3 +20,23 @@ module Goldencobra
       end
   end
 end
+
+# == Schema Information
+#
+# Table name: goldencobra_uploads
+#
+#  id                 :integer          not null, primary key
+#  source             :string(255)
+#  rights             :string(255)
+#  description        :text(65535)
+#  image_file_name    :string(255)
+#  image_content_type :string(255)
+#  image_file_size    :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  attachable_id      :integer
+#  attachable_type    :string(255)
+#  alt_text           :string(255)
+#  sorter_number      :integer
+#  image_remote_url   :string(255)
+#

--- a/app/views/goldencobra/admin/articles/_layout_sidebar.html.erb
+++ b/app/views/goldencobra/admin/articles/_layout_sidebar.html.erb
@@ -21,7 +21,7 @@
     <h5>
       <%= I18n.t(@article.article_type.split(' ').first.to_s.strip, :scope => [:activerecord, :models, "goldencobra/article"], :default => "Layout der Seite") %>
     </h5>
-    <%= f.select :template_file, Goldencobra::Article.templates_for_select, :include_blank => false %>
+    <%= f.select :template_file, @article.articletype.templates.map { |t| [t.title, t.layout_file_name]}, :include_blank => false %>
     <br/><br/>
     <%= f.submit t("submit_layout", :scope => [:active_admin, :sidebars]) %>
   <% end %>

--- a/config/initializers/templates.rb
+++ b/config/initializers/templates.rb
@@ -1,0 +1,15 @@
+Rails.application.config.to_prepare do
+  if ActiveRecord::Base.connection.table_exists?("goldencobra_templates")
+    # Beim starten der Application wird das Verzeichnis /app/views/layouts durchsucht nach
+    # neuen Templatefiles und erzeugt für diese dann eine Goldencobra::Template
+    Goldencobra::Template.layouts_for_select.each do |template_file_name|
+      template = Goldencobra::Template.where(layout_file_name: template_file_name).first
+      unless template
+        template = Goldencobra::Template.create(layout_file_name: template_file_name, title: template_file_name)
+        Goldencobra::Articletype.all.each do |at|
+          at.templates << template
+        end
+      end
+    end
+  end
+end

--- a/config/locales/active_admin.de.yml
+++ b/config/locales/active_admin.de.yml
@@ -44,6 +44,8 @@ de:
       div: "Ich akzeptiere die AGB & Datenschutzbestimmungen *"
       submit: "Registrieren"
   active_admin:
+    template:
+      as: "Templates"
     redirector:
       as: "Weiterleitungen"
     article_url:
@@ -629,6 +631,8 @@ de:
       as: "Artikeltypen"
       general: "Allgemein"
       article_fields: "Artikelfelder"
+      default_template: "Standard Layout"
+      templates: "Verfügbare Templates"
       position_hint: "Zwischen dem ersten und dem letzten Block kommen die speziellen Feldoptionen eines Artikeltypen"
       foldable_hint: "Kann man den Bereich auf und zu klappen?"
       closed_hint: "Ist der Bereich beim Laden geschlossen?"

--- a/config/locales/active_admin.en.yml
+++ b/config/locales/active_admin.en.yml
@@ -44,6 +44,8 @@ en:
       div: "I accept AGB & Privacy Policy *"
       submit: "Sign-up"
   active_admin:
+    template:
+      as: "Templates"
     redirector:
       as: "Redirections"
     article_url:
@@ -629,6 +631,8 @@ en:
       as: "Article types"
       general: "General"
       article_fields: "Article fields"
+      default_template: "Default Layout"
+      templates: "Available Templates"
       position_hint: "Field options of article type between first and last block"
       foldable_hint: "Is this part foldable?"
       closed_hint: "Is this part closed on load?"

--- a/db/migrate/20180308124139_create_goldencobra_templates.rb
+++ b/db/migrate/20180308124139_create_goldencobra_templates.rb
@@ -1,0 +1,10 @@
+class CreateGoldencobraTemplates < ActiveRecord::Migration
+  def change
+    create_table :goldencobra_templates do |t|
+      t.string :title
+      t.string :layout_file_name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180308124302_create_goldencobra_articletype_templates.rb
+++ b/db/migrate/20180308124302_create_goldencobra_articletype_templates.rb
@@ -1,0 +1,10 @@
+class CreateGoldencobraArticletypeTemplates < ActiveRecord::Migration
+  def change
+    create_table :goldencobra_articletype_templates do |t|
+      t.integer :articletype_id
+      t.integer :template_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -13,10 +13,8 @@ Gem::Specification.new do |s|
   s.summary     = "Basic CMS based on Rails engines"
   s.description = "This is the basic module of Golden Cobra. It offers Devise, ActiveAdmin, an article module, a menu module and global settings for an CMS"
   s.licenses    = "Lizenz CC BY-NC-SA 3.0"
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["CC-LICENSE", "Rakefile", "README.markdown"]
-  s.metadata = {
-    "changelog_uri"     => "https://github.com/ikuseiGmbH/Goldencobra/blob/master/doc/versionhistory"
-  }
+  s.files       = Dir["{app,config,db,lib}/**/*"] + ["CC-LICENSE", "Rakefile", "README.markdown"]
+  s.metadata    = { "changelog_uri" => "https://github.com/ikuseiGmbH/Goldencobra/blob/master/doc/versionhistory" }
   # s.test_files = Dir["test/**/*"]
 
   # Post Install Message

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160704070529) do
+ActiveRecord::Schema.define(version: 20180308124302) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.integer  "resource_id",   limit: 4,     null: false
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 20160704070529) do
     t.string   "metatag_open_graph_url",              limit: 255
     t.string   "metatag_open_graph_image",            limit: 255
     t.integer  "state",                               limit: 4,     default: 0
-    t.boolean  "display_index_articles",                            default: true
+    t.boolean  "display_index_articles",                            default: false
   end
 
   add_index "goldencobra_articles", ["active"], name: "index_goldencobra_articles_on_active", using: :btree
@@ -155,6 +155,13 @@ ActiveRecord::Schema.define(version: 20160704070529) do
     t.datetime "created_at",                                         null: false
     t.datetime "updated_at",                                         null: false
     t.string   "position",       limit: 255, default: "first_block"
+  end
+
+  create_table "goldencobra_articletype_templates", force: :cascade do |t|
+    t.integer  "articletype_id", limit: 4
+    t.integer  "template_id",    limit: 4
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   create_table "goldencobra_articletypes", force: :cascade do |t|
@@ -331,6 +338,13 @@ ActiveRecord::Schema.define(version: 20160704070529) do
   add_index "goldencobra_settings", ["ancestry"], name: "index_goldencobra_articles_on_ancestry", using: :btree
   add_index "goldencobra_settings", ["title", "ancestry"], name: "index_goldencobra_articles_on_title_and_ancestry", using: :btree
   add_index "goldencobra_settings", ["title"], name: "index_goldencobra_articles_on_title", using: :btree
+
+  create_table "goldencobra_templates", force: :cascade do |t|
+    t.string   "title",            limit: 255
+    t.string   "layout_file_name", limit: 255
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
 
   create_table "goldencobra_trackings", force: :cascade do |t|
     t.text     "request",        limit: 65535

--- a/test/dummy/spec/models/article_spec.rb
+++ b/test/dummy/spec/models/article_spec.rb
@@ -136,11 +136,11 @@ describe Goldencobra::Article do
       File.new("#{::Rails.root}/app/views/layouts/_partial_2.html.erb", "w")
       File.new("#{::Rails.root}/app/views/layouts/12layout.html.erb", "w")
 
-      expect(Goldencobra::Article.templates_for_select.include?("tim_test")).to eq true
-      expect(Goldencobra::Article.templates_for_select.include?("_partial")).to eq false
-      expect(Goldencobra::Article.templates_for_select.include?("_partial_2")).to eq false
-      expect(Goldencobra::Article.templates_for_select.include?("application")).to eq true
-      expect(Goldencobra::Article.templates_for_select.include?("12layout")).to eq true
+      expect(Goldencobra::Article.layouts_for_select.include?("tim_test")).to eq true
+      expect(Goldencobra::Article.layouts_for_select.include?("_partial")).to eq false
+      expect(Goldencobra::Article.layouts_for_select.include?("_partial_2")).to eq false
+      expect(Goldencobra::Article.layouts_for_select.include?("application")).to eq true
+      expect(Goldencobra::Article.layouts_for_select.include?("12layout")).to eq true
 
       File.delete("#{::Rails.root}/app/views/layouts/tim_test.html.erb")
       File.delete("#{::Rails.root}/app/views/layouts/_partial.html.erb")


### PR DESCRIPTION
Es gibt nun ein eigenes Model für die Templates.

Teile der bisherigen Lösung wurden bereits in das neue Model ausgelagert.
Zusätzlich gibt es einen Zusammenhang von Artikeltypen und Templates: 
Ein Artikeltyp kann definieren welche Templates/Layouts zur Verfügung stehen.
Dies wirkt sich beim Artikel-Edit in der Seitenleiste aus. Dort werden jetzt nur noch die verfügbaren 
Layout aufgelistet

<img width="304" alt="bildschirmfoto 2018-03-09 um 13 24 41" src="https://user-images.githubusercontent.com/90779/37207431-3f43c378-239d-11e8-9fd7-74cf619c6d0f.png">
<img width="557" alt="bildschirmfoto 2018-03-09 um 13 20 31" src="https://user-images.githubusercontent.com/90779/37207432-3f66b734-239d-11e8-9f2e-0e2579a519c7.png">
<img width="274" alt="bildschirmfoto 2018-03-09 um 13 20 19" src="https://user-images.githubusercontent.com/90779/37207433-3f86243e-239d-11e8-8380-2bcb9f31b267.png">
