### PR TITLE
Remove Bootstrap 3 gem from gemspec

### DIFF
--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -72,7 +72,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack-action_caching"
   s.add_dependency "react-rails", "~> 1.0"
   s.add_dependency "oj" # faster json rendering
-  s.add_dependency "bootstrap-sass", "~> 3.3" # frontend template framework
   s.add_dependency "font-awesome-sass"
   s.add_dependency "autoprefixer-rails" # to provide easy automatic css prefixing
 


### PR DESCRIPTION
Gemspec was specifying bootstrap 3 gem. The problem with that was that any host application which uses Goldencobra
cannot use any other bootstrap version via the gem.
This commit will remove bootstrap 3 gem from gemspec. By that it is possible to e.g use the bootstrap 4 gem with GC
in any host application, together with the Goldencobra Engine.

## Changes proposed in this PR:

Commit will remove bootstrap 3 gem from gemspec.

#####ATTENTION templates created by Goldencobra will not work without the bs3 gem anymore. This needs to be fixed in a future commit. This  issue needs to be added to the docs, after this commit is merged.



