### PR TITLE
Remove Bootstrap 3 gem from gemspec

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -218,6 +218,7 @@ in your view_templates:
 <%= yield(:article_subtitle) %>
 <%= yield(:article_teaser) %>
 ```
+!!!Attention!!! The layouts' styling will only work if you include `gem bootstrap-sass` in Your Gemfile
 
 ## Render widgets
 

--- a/README.markdown
+++ b/README.markdown
@@ -219,7 +219,7 @@ in your view_templates:
 <%= yield(:article_teaser) %>
 ```
 #### !!!Attention!!!
-The layouts' styling will only work if you include [`gem bootstrap-sass`](https://github.com/twbs/bootstrap-sass) in Your Gemfile.
+The layouts' styling will only work if you include [`gem bootstrap-sass`](https://github.com/twbs/bootstrap-sass) in your Gemfile.
 
 ## Render widgets
 

--- a/README.markdown
+++ b/README.markdown
@@ -218,7 +218,8 @@ in your view_templates:
 <%= yield(:article_subtitle) %>
 <%= yield(:article_teaser) %>
 ```
-!!!Attention!!! The layouts' styling will only work if you include `gem bootstrap-sass` in Your Gemfile
+#### !!!Attention!!!
+The layouts' styling will only work if you include [`gem bootstrap-sass`](https://github.com/twbs/bootstrap-sass) in Your Gemfile.
 
 ## Render widgets
 

--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -74,7 +74,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack-action_caching"
   s.add_dependency "react-rails", "~> 1.0"
   s.add_dependency "oj" # faster json rendering
-  s.add_dependency "bootstrap-sass", "~> 3.3" # frontend template framework
   s.add_dependency "font-awesome-sass"
   s.add_dependency "autoprefixer-rails" # to provide easy automatic css prefixing
 


### PR DESCRIPTION
Gemspec was specifying bootstrap 3 gem. The problem with that was that any host application which uses Goldencobra
cannot use any other bootstrap version via the gem.
This commit will remove bootstrap 3 gem from gemspec. By that it is possible to e.g use the bootstrap 4 gem with GC
in any host application, together with the Goldencobra Engine. It will add additional info to the Readme that the old auto-generated layouts
will not be styled correctly with that commit and what to do to have the correct styling available
