### PR TITLE
admin widget form split up

### DIFF
--- a/admin/widgets.rb
+++ b/admin/widgets.rb
@@ -47,10 +47,11 @@ ActiveAdmin.register Goldencobra::Widget, as: "Widget" do
         p.input :_destroy, as: :boolean
       end
     end
-    f.inputs I18n.t('active_admin.widget.article') do
-      f.input :articles, label: I18n.t('active_admin.widget.article_label'), hint: I18n.t('active_admin.widget.article_hint'), as: :select, collection: Goldencobra::Article.all.map { |a| [a.parent_path, a.id] }.sort, input_html: { class: "chosen-select", "data-placeholder" => I18n.t("active_admin.widget.article_placeholder"), "style" => "width: 70%;" }
-    end
     f.actions
+  end
+
+  sidebar :assign_article, only: %i[edit] do
+    render "/goldencobra/admin/widgets/article_widgets_sidebar", locals: { resource: resource }
   end
 
   sidebar :layout_positions, only: [:edit] do
@@ -117,6 +118,17 @@ ActiveAdmin.register Goldencobra::Widget, as: "Widget" do
         end
       end
     end
+  end
+
+  member_action :connect_with_articles, method: :post do
+    Goldencobra::ArticleWidget.where(widget_id: params[:id]).delete_all
+    params[:widget][:articles].each do |article_id|
+      next if article_id.blank?
+
+      resource.articles << Goldencobra::Article.find_by(id: article_id)
+    end
+
+    redirect_to action: :edit
   end
 
   member_action :revert do

--- a/app/views/goldencobra/admin/widgets/_article_widgets_sidebar.html.erb
+++ b/app/views/goldencobra/admin/widgets/_article_widgets_sidebar.html.erb
@@ -1,0 +1,8 @@
+<%= form_for(resource, url: connect_with_articles_admin_widget_path, method: :post) do |f| %>
+  <%= f.select :articles,
+                options_from_collection_for_select(Goldencobra::Article.all, "id", "parent_path", resource.article_ids),
+                { include_blank: true },
+                { multiple: true, class: "chosen-select-deselect" }  %>
+  <br/><br/>
+  <%= f.submit I18n.t('active_admin.widget.sidebar.articles.submit') %>
+<% end %>

--- a/config/locales/active_admin.de.yml
+++ b/config/locales/active_admin.de.yml
@@ -559,6 +559,9 @@ de:
       yes_check: "Ja"
       no_check: "Nein"
     widget:
+      sidebar:
+        articles:
+          submit: "Artikel zuordnen"
       as: "Schnipsel"
       parent: "Content-Management"
       title: "Titel"
@@ -647,4 +650,3 @@ de:
           title1: "Bearbeiten"
           link2: "neu"
           title2: "Neu"
-

--- a/doc/versionhistory
+++ b/doc/versionhistory
@@ -1,3 +1,5 @@
+V2.3.12 - 31.08.2020
+  - Split up admin widget form to separate updates of article-widget-assignments
 V2.3.11 - 28.05.2020
   - Updated `input_form_for` method to pass `include_blank` values correctly
 V2.3.10 - 18.05.2020

--- a/lib/goldencobra/version.rb
+++ b/lib/goldencobra/version.rb
@@ -1,3 +1,3 @@
 module Goldencobra
-  VERSION = "2.3.11".freeze
+  VERSION = "2.3.12".freeze
 end


### PR DESCRIPTION
Split up admin widget form to separate updates of article-widget-assignments.

Now, the article-widget_ids are only be updated if the separate form is submitted. This reduces the danger of overwriting changes made in the article form.
