### PR TITLE
feat: update order and presentation of template selection for editing article types

### DIFF
--- a/admin/articletypes.rb
+++ b/admin/articletypes.rb
@@ -23,10 +23,15 @@ ActiveAdmin.register Goldencobra::Articletype, as: "Articletype" do
   form html: { enctype: "multipart/form-data" }  do |f|
     f.actions
     f.inputs I18n.t("active_admin.articletypes.general") do
-      f.input :default_template_file, as: :select,
-              collection: Goldencobra::Template.all.map { |t| [t.title, t.layout_file_name]}, include_blank: false,
+      f.input :default_template_file,
+              as: :select,
+              collection: Goldencobra::Template.order(:layout_file_name).pluck(:layout_file_name).uniq,
+              include_blank: false,
               label: I18n.t("active_admin.articletypes.default_template")
-      f.input :templates, as: :check_boxes, collection: Goldencobra::Template.all.map { |t| [t.title, t.id]}, label: I18n.t("active_admin.articletypes.templates")
+      f.input :templates,
+              as: :check_boxes,
+              collection: Goldencobra::Template.order(:title).map { |t| [t.title, t.id]},
+              label: I18n.t("active_admin.articletypes.templates")
     end
     f.inputs I18n.t("active_admin.articletypes.article_fields"), class: "foldable" do
       f.has_many :fieldgroups, heading: "", new_record: "+ Feldgruppe hinzufügen" do |fg|

--- a/doc/versionhistory
+++ b/doc/versionhistory
@@ -1,3 +1,5 @@
+V2.3.13 - 12.10.2020
+  - update order and presentation of template selects for editing article types
 V2.3.12 - 31.08.2020
   - Split up admin widget form to separate updates of article-widget-assignments
 V2.3.11 - 28.05.2020

--- a/lib/goldencobra/version.rb
+++ b/lib/goldencobra/version.rb
@@ -1,3 +1,3 @@
 module Goldencobra
-  VERSION = "2.3.12".freeze
+  VERSION = "2.3.13".freeze
 end


### PR DESCRIPTION
- updated select values to distinguish from check boxes values
- added alphabetical ordering for select and checkboxes

before | after
------------ | -------------
<img width="731" alt="old" src="https://user-images.githubusercontent.com/1942953/95735415-0f313980-0c85-11eb-9557-67969126cb8a.png"> | <img width="667" alt="Bildschirmfoto 2020-10-12 um 12 11 42" src="https://user-images.githubusercontent.com/1942953/95735422-11939380-0c85-11eb-8f1b-caebd76b4ce2.png">

a default template is the layout file. available templates are more than just the layout file.